### PR TITLE
fix(demo): move demo content

### DIFF
--- a/lib/presentation/demo/components_demo/components_demo_screen.dart
+++ b/lib/presentation/demo/components_demo/components_demo_screen.dart
@@ -1,13 +1,13 @@
-import 'package:collaction_app/presentation/shared_widgets/accent_action_chip.dart';
-import 'package:collaction_app/presentation/shared_widgets/crowdaction_card.dart';
-import 'package:collaction_app/presentation/shared_widgets/custom_fab.dart';
 import 'package:flutter/material.dart';
 
-import '../shared_widgets/accent_chip.dart';
-import '../shared_widgets/custom_appbar.dart';
-import '../shared_widgets/pill_button.dart';
-import '../shared_widgets/rectangle_button.dart';
-import '../shared_widgets/secondary_chip.dart';
+import '../../shared_widgets/accent_action_chip.dart';
+import '../../shared_widgets/accent_chip.dart';
+import '../../shared_widgets/crowdaction_card.dart';
+import '../../shared_widgets/custom_appbar.dart';
+import '../../shared_widgets/custom_fab.dart';
+import '../../shared_widgets/pill_button.dart';
+import '../../shared_widgets/rectangle_button.dart';
+import '../../shared_widgets/secondary_chip.dart';
 
 class ComponentsDemoPage extends StatefulWidget {
   const ComponentsDemoPage({Key? key}) : super(key: key);

--- a/lib/presentation/demo/demo_screen.dart
+++ b/lib/presentation/demo/demo_screen.dart
@@ -1,0 +1,66 @@
+import 'package:auto_route/auto_route.dart';
+import 'package:collaction_app/presentation/shared_widgets/custom_appbar.dart';
+import 'package:flutter/material.dart';
+
+import '../routes/app_routes.gr.dart';
+import '../shared_widgets/rectangle_button.dart';
+
+class DemoPage extends StatelessWidget {
+  const DemoPage({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: CustomAppBar(context),
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 30.0, horizontal: 24.0),
+          child: Column(
+            children: [
+              const Text(
+                'Welcome to Demo Screen!',
+                style: TextStyle(fontWeight: FontWeight.w700, fontSize: 34.0),
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 30.0),
+              Row(
+                children: [
+                  Expanded(
+                    child: RectangleButton(
+                      text: "Reusable Components",
+                      onTap: () =>
+                          context.router.push(const ComponentsDemoRoute()),
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 10.0),
+              Row(
+                children: [
+                  Expanded(
+                    child: RectangleButton(
+                      text: "Contact Form",
+                      onTap: () =>
+                          context.router.push(const ContactFormRoute()),
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 10.0),
+              Row(
+                children: [
+                  Expanded(
+                    child: RectangleButton(
+                      text: "Onboarding",
+                      onTap: () => context.router.push(const OnboardingRoute()),
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/home/home_screen.dart
+++ b/lib/presentation/home/home_screen.dart
@@ -60,17 +60,6 @@ class HomePage extends StatelessWidget {
                           ],
                         ),
                         const CrowdActionCarousel(),
-                        ElevatedButton(
-                          onPressed: () =>
-                              context.router.push(const ContactFormRoute()),
-                          child:
-                              const Text('Give feedback or start crowd action'),
-                        ),
-                        ElevatedButton(
-                          onPressed: () =>
-                              context.router.push(const ComponentsDemoRoute()),
-                          child: const Text('UI Components Demo Page'),
-                        ),
                       ],
                     ),
                   ),

--- a/lib/presentation/routes/app_routes.dart
+++ b/lib/presentation/routes/app_routes.dart
@@ -1,9 +1,10 @@
 import 'package:auto_route/annotations.dart';
-import 'package:collaction_app/presentation/crowd_action/crowd_action_details.dart';
 
-import '../components_demo/components_demo_screen.dart';
 import '../contact_form/contact_form_screen.dart';
 import '../crowd_action/crowd_action_browse.dart';
+import '../crowd_action/crowd_action_details.dart';
+import '../demo/components_demo/components_demo_screen.dart';
+import '../demo/demo_screen.dart';
 import '../home/home_screen.dart';
 import '../onboarding/onboarding.dart';
 
@@ -16,6 +17,7 @@ import '../onboarding/onboarding.dart';
     AutoRoute(page: ComponentsDemoPage),
     AutoRoute(page: OnboardingPage),
     AutoRoute(page: CrowdActionDetailsPage),
+    AutoRoute(page: DemoPage),
   ],
 )
 class $AppRouter {}

--- a/lib/presentation/shared_widgets/menu_drawer.dart
+++ b/lib/presentation/shared_widgets/menu_drawer.dart
@@ -1,4 +1,5 @@
 import 'package:auto_route/auto_route.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_advanced_drawer/flutter_advanced_drawer.dart';
 
@@ -17,6 +18,68 @@ class MenuDrawer extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    var drawerItems = <Widget>[
+      const Padding(
+        padding: EdgeInsets.symmetric(vertical: 15.0, horizontal: 15),
+        child: Text(
+          'Menu',
+          style: TextStyle(fontSize: 35, fontWeight: FontWeight.w500),
+        ),
+      ),
+      ListTile(
+        onTap: () {},
+        leading: const Icon(Icons.group_add, size: 27),
+        title: const Text('Invite friends'),
+      ),
+      const Divider(
+        color: Colors.black38,
+        height: 1,
+      ),
+      ListTile(
+        onTap: () => pushRoute(context, const CrowdActionBrowseRoute()),
+        leading: const ImageIcon(
+          AssetImage('assets/images/icons/browse.png'),
+          size: 24,
+        ),
+        title: const Text('Browse'),
+      ),
+      ListTile(
+        onTap: () {}, // TODO: Own crowdactions / participating in ...
+        leading: const ImageIcon(
+          AssetImage('assets/images/icons/check.png'),
+          size: 24,
+        ),
+        title: const Text('My Crowdactions'),
+      ),
+      ListTile(
+        onTap: () {}, // TODO: Add profile route
+        leading: const CircleAvatar(
+          backgroundColor: Colors.black,
+          maxRadius: 15,
+          child: Icon(
+            Icons.person,
+            color: Colors.white,
+            size: 20,
+          ),
+        ),
+        title: const Text('Profile'),
+      ),
+      ListTile(
+        onTap: () => pushRoute(context, const ContactFormRoute()),
+        leading: const Icon(Icons.mail_outline_outlined, size: 27),
+        title: const Text('Contact Us'),
+      )
+    ];
+
+    if (!kReleaseMode) {
+      // Demo content should not be visible in release builds
+      drawerItems.add(ListTile(
+        onTap: () => pushRoute(context, const DemoRoute()),
+        leading: const Icon(Icons.list_alt, size: 27),
+        title: const Text('Demo Content'),
+      ));
+    }
+
     return AdvancedDrawer(
       backdropColor: Colors.white,
       controller: _advancedDrawerController,
@@ -24,63 +87,7 @@ class MenuDrawer extends StatelessWidget {
         textColor: Colors.black,
         iconColor: Colors.black,
         child: ListView(
-          children: [
-            const Padding(
-              padding: EdgeInsets.symmetric(vertical: 15.0, horizontal: 15),
-              child: Text(
-                'Menu',
-                style: TextStyle(fontSize: 35, fontWeight: FontWeight.w500),
-              ),
-            ),
-            ListTile(
-              onTap: () {},
-              leading: const Icon(Icons.group_add, size: 27),
-              title: const Text('Invite friends'),
-            ),
-            const Divider(
-              color: Colors.black38,
-              height: 1,
-            ),
-            ListTile(
-              onTap: () => pushRoute(context, const CrowdActionBrowseRoute()),
-              leading: const ImageIcon(
-                AssetImage('assets/images/icons/browse.png'),
-                size: 24,
-              ),
-              title: const Text('Browse'),
-            ),
-            ListTile(
-              onTap: () {}, // TODO: Own crowdactions / participating in ...
-              leading: const ImageIcon(
-                AssetImage('assets/images/icons/check.png'),
-                size: 24,
-              ),
-              title: const Text('My Crowdactions'),
-            ),
-            ListTile(
-              onTap: () {}, // TODO: Add profile route
-              leading: const CircleAvatar(
-                backgroundColor: Colors.black,
-                maxRadius: 15,
-                child: Icon(
-                  Icons.person,
-                  color: Colors.white,
-                  size: 20,
-                ),
-              ),
-              title: const Text('Profile'),
-            ),
-            ListTile(
-              onTap: () => pushRoute(context, const ContactFormRoute()),
-              leading: const Icon(Icons.mail_outline_outlined, size: 27),
-              title: const Text('Contact Us'),
-            ),
-            ListTile(
-              onTap: () => pushRoute(context, const DemoRoute()),
-              leading: const Icon(Icons.list_alt, size: 27),
-              title: const Text('Demo Content'),
-            ),
-          ],
+          children: drawerItems,
         ),
       ),
       child: child,

--- a/lib/presentation/shared_widgets/menu_drawer.dart
+++ b/lib/presentation/shared_widgets/menu_drawer.dart
@@ -75,6 +75,11 @@ class MenuDrawer extends StatelessWidget {
               leading: const Icon(Icons.mail_outline_outlined, size: 27),
               title: const Text('Contact Us'),
             ),
+            ListTile(
+              onTap: () => pushRoute(context, const DemoRoute()),
+              leading: const Icon(Icons.list_alt, size: 27),
+              title: const Text('Demo Content'),
+            ),
           ],
         ),
       ),

--- a/lib/presentation/shared_widgets/menu_drawer.dart
+++ b/lib/presentation/shared_widgets/menu_drawer.dart
@@ -18,7 +18,7 @@ class MenuDrawer extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    var drawerItems = <Widget>[
+    final drawerItems = <Widget>[
       const Padding(
         padding: EdgeInsets.symmetric(vertical: 15.0, horizontal: 15),
         child: Text(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -14,7 +14,7 @@ packages:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.2"
+    version: "1.7.1"
   archive:
     dependency: transitive
     description:
@@ -35,7 +35,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.1"
+    version: "2.6.1"
   auto_route:
     dependency: "direct main"
     description:
@@ -140,7 +140,7 @@ packages:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.1"
+    version: "1.2.0"
   checked_yaml:
     dependency: transitive
     description:
@@ -428,7 +428,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.3.0"
   mime:
     dependency: transitive
     description:
@@ -622,21 +622,21 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.17.10"
+    version: "1.16.8"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.2"
+    version: "0.3.0"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.0"
+    version: "0.3.19"
   timing:
     dependency: transitive
     description:


### PR DESCRIPTION
Let us not have demo content on actual UI.

All demo content should either have a button on the demo screen page that will push the route or be reachable by the actual implementation. (Onboarding and Reusable components screens aren't easily reachable, now they are)