### PR TITLE
Update remote config values as soon as the app starts

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
 
+import 'domain/i_settings_repository.dart';
 import 'infrastructure/core/injection.dart';
 import 'presentation/routes/app_routes.gr.dart' as app_router;
 import 'presentation/themes/themes.dart';
@@ -10,6 +11,8 @@ Future<void> main() async {
   await Firebase.initializeApp();
 
   configureInjection();
+  // Instantiate to trigger update of remote configs
+  getIt<ISettingsRepository>();
 
   runApp(AppWidget());
 }


### PR DESCRIPTION
Fixes #36 

Adding this one line resolves the issue by downloading the latest remote configs as soon as the app starts.
This is by far the simplest and last "hacky" solution, because using a `Singleton` instead of a `LazySingleton` causes issues since Firebase is not initialized in the tests.