### PR TITLE
Hide button for sharing crowdaction that does nothing

### DIFF
--- a/lib/presentation/crowd_action/pages/crowd_action_details.dart
+++ b/lib/presentation/crowd_action/pages/crowd_action_details.dart
@@ -1,4 +1,5 @@
 import 'package:auto_route/auto_route.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
 import '../../../domain/crowdaction/crowdaction.dart';
@@ -45,6 +46,7 @@ class CrowdActionDetailsPage extends StatelessWidget {
                   const Expanded(
                     child: SizedBox(),
                   ),
+                  /* TODO implement crowdaction sharing
                   ElevatedButton(
                     onPressed: () {},
                     style: ElevatedButton.styleFrom(
@@ -52,9 +54,9 @@ class CrowdActionDetailsPage extends StatelessWidget {
                       primary: kAccentColor,
                       onPrimary: kAccentColor,
                     ),
-                    child: const Icon(Icons.upload, color: Colors.white),
+                    child: const Icon(CupertinoIcons.share, color: Colors.white),
                   )
-                  // Your widgets here
+                  */
                 ],
               ),
               flexibleSpace: FlexibleSpaceBar(


### PR DESCRIPTION
Apple may reject the app if it contains obvious placeholder content or other unfinished features.