### PR TITLE
Distribute iOS and Android using seperate jobs with correct OS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,9 +167,9 @@ jobs:
         path: build/ios/iphoneos/app.ipa
 
   # TODO Update to distribute appbundle once released
-  distribute:
+  distribute_android:
     needs: [build]
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Download generated apk from the artifacts
         uses: actions/download-artifact@v2
@@ -182,6 +182,11 @@ jobs:
           token: ${{secrets.FIREBASE_TOKEN}}
           groups: internal
           file: flutter-apk/app-signed.apk
+
+  distribute_ios:
+    needs: [build]
+    runs-on: macos-latest
+    steps:
       - name: Download generated ipa from the artifacts
         uses: actions/download-artifact@v2
         with:

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -43,8 +43,7 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
-	<!-- TODO verify this API usage and explanation -->
 	<key>NSPhotoLibraryUsageDescription</key>
-	<string>Select and upload a picture from from the Photo Library to use as a profile picture in the app.</string>
+	<string>Select and upload a picture from the Photo Library to use as a profile picture in the app.</string>
 </dict>
 </plist>


### PR DESCRIPTION
Unfortunately, it is not only that distribution of an iOS build is only possible on macOS, but also the workflow action for distribution of the android build to Firebase is only available on Linux.  
The solution is to start two separate jobs.