### PR TITLE
Define associated domains on iOS (currently none)

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -45,5 +45,9 @@
 	<false/>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>Select and upload a picture from the Photo Library to use as a profile picture in the app.</string>
+	<key>com.apple.developer.associated-domains</key>
+	<array>
+		<!-- TODO add "Open with CollAction" in the future -->
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
(Fingers crossed this is the last issue with iOS 😿)