### PR TITLE
Feat/store linking

### DIFF
--- a/lib/presentation/crowd_action/pages/widgets/share_collaction_card.dart
+++ b/lib/presentation/crowd_action/pages/widgets/share_collaction_card.dart
@@ -7,7 +7,10 @@ import '../../../themes/constants.dart';
 class ShareCollActionCard extends StatelessWidget {
   // TODO Review (and update) text being shared.
   static const shareText =
-      "Check out https://collaction.org and let's solve all collective action problems in the world.";
+      "Check out CollAction at https://play.google.com/store/apps/details?id=org.collaction.collaction_app" +
+          " for Android and https://apps.apple.com/nl/app/id1597643827 for iOS." +
+          " Let's solve all collective action problems in the world.";
+
   static const shareEmailSubject = "Join me on CollAction";
 
   const ShareCollActionCard({

--- a/lib/presentation/crowd_action/pages/widgets/share_collaction_card.dart
+++ b/lib/presentation/crowd_action/pages/widgets/share_collaction_card.dart
@@ -7,9 +7,7 @@ import '../../../themes/constants.dart';
 class ShareCollActionCard extends StatelessWidget {
   // TODO Review (and update) text being shared.
   static const shareText =
-      "Check out CollAction at https://play.google.com/store/apps/details?id=org.collaction.collaction_app" +
-          " for Android and https://apps.apple.com/app/id1597643827 for iOS." +
-          " Let's solve all collective action problems in the world.";
+      "Check out CollAction at https://play.google.com/store/apps/details?id=org.collaction.collaction_app for Android and https://apps.apple.com/app/id1597643827 for iOS. Let's solve all collective action problems in the world.";
 
   static const shareEmailSubject = "Join me on CollAction";
 

--- a/lib/presentation/crowd_action/pages/widgets/share_collaction_card.dart
+++ b/lib/presentation/crowd_action/pages/widgets/share_collaction_card.dart
@@ -8,7 +8,7 @@ class ShareCollActionCard extends StatelessWidget {
   // TODO Review (and update) text being shared.
   static const shareText =
       "Check out CollAction at https://play.google.com/store/apps/details?id=org.collaction.collaction_app" +
-          " for Android and https://apps.apple.com/nl/app/id1597643827 for iOS." +
+          " for Android and https://apps.apple.com/app/id1597643827 for iOS." +
           " Let's solve all collective action problems in the world.";
 
   static const shareEmailSubject = "Join me on CollAction";


### PR DESCRIPTION
Simple App Store / Play Store linking in share text. The (Google) Play Store identifies apps through a bundle identifier taken from the app level `build.gradle` and the (iOS) App Store uses a AppId which is taken from the appstoreconnect info page. Both should open the corresponding application depending on the device although I've only been able to test on a physical android device (which works). Note that the pages don't exist _yet_ or are not yet publicly visible.