### PR TITLE
Add url type to info.plist

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -20,6 +20,17 @@
 	<string>$(FLUTTER_BUILD_NAME)</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>com.googleusercontent.apps.164614571144-e8b9m24eq9tgvnrqrcc91e5lvteqpp17</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>LSRequiresIPhoneOS</key>


### PR DESCRIPTION
Fixed issue with iOS phone registrations.

Reversed_client_id was missing from url types in the info.plist, variable came from googleService-Info.plist.

Step is also explained in firebase docs [here](https://firebase.google.com/docs/auth/ios/phone-auth#set-up-recaptcha-verification)