### PR TITLE
fix: refactor crowdaction details screen

### DIFF
--- a/lib/application/crowdaction/crowdaction_details/crowdaction_details_bloc.dart
+++ b/lib/application/crowdaction/crowdaction_details/crowdaction_details_bloc.dart
@@ -1,0 +1,36 @@
+import 'package:bloc/bloc.dart';
+import 'package:collaction_app/domain/crowdaction/crowdaction.dart';
+import 'package:collaction_app/domain/crowdaction/crowdaction_failures.dart';
+import 'package:collaction_app/domain/crowdaction/i_crowdaction_repository.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+import 'package:injectable/injectable.dart';
+
+part 'crowdaction_details_event.dart';
+part 'crowdaction_details_state.dart';
+part 'crowdaction_details_bloc.freezed.dart';
+
+@injectable
+class CrowdActionDetailsBloc
+    extends Bloc<CrowdActionDetailsEvent, CrowdActionDetailsState> {
+  final ICrowdActionRepository crowdActionRepository;
+
+  CrowdActionDetailsBloc(this.crowdActionRepository) : super(const _Initial()) {
+    on<CrowdActionDetailsEvent>((event, emit) async {
+      await event.when(
+        fetchCrowdAction: (crowdActionId) async {
+          final crowdActionOrFailure =
+              await crowdActionRepository.getCrowdAction(crowdActionId);
+
+          crowdActionOrFailure.fold(
+            (failure) {
+              emit(CrowdActionDetailsState.loadFailure(failure));
+            },
+            (crowdAction) {
+              emit(CrowdActionDetailsState.loadSuccess(crowdAction));
+            },
+          );
+        },
+      );
+    });
+  }
+}

--- a/lib/application/crowdaction/crowdaction_details/crowdaction_details_event.dart
+++ b/lib/application/crowdaction/crowdaction_details/crowdaction_details_event.dart
@@ -1,0 +1,7 @@
+part of 'crowdaction_details_bloc.dart';
+
+@freezed
+class CrowdActionDetailsEvent with _$CrowdActionDetailsEvent {
+  const factory CrowdActionDetailsEvent.fetchCrowdAction({required String id}) =
+      _FetchCrowdAction;
+}

--- a/lib/application/crowdaction/crowdaction_details/crowdaction_details_state.dart
+++ b/lib/application/crowdaction/crowdaction_details/crowdaction_details_state.dart
@@ -1,0 +1,12 @@
+part of 'crowdaction_details_bloc.dart';
+
+@freezed
+class CrowdActionDetailsState with _$CrowdActionDetailsState {
+  const factory CrowdActionDetailsState.initial() = _Initial;
+  const factory CrowdActionDetailsState.loadInProgress() = _LoadInProgress;
+  const factory CrowdActionDetailsState.loadSuccess(CrowdAction crowdAction) =
+      _LoadSuccess;
+  const factory CrowdActionDetailsState.loadFailure(
+    CrowdActionFailure crowdactionFailure,
+  ) = _LoadFailure;
+}

--- a/lib/domain/crowdaction/i_crowdaction_repository.dart
+++ b/lib/domain/crowdaction/i_crowdaction_repository.dart
@@ -5,6 +5,10 @@ import 'crowdaction_failures.dart';
 import 'crowdaction_status.dart';
 
 abstract class ICrowdActionRepository {
+  Future<Either<CrowdActionFailure, CrowdAction>> getCrowdAction(
+    String id,
+  );
+
   Future<Either<CrowdActionFailure, List<CrowdAction>>> getCrowdActions({
     int amount = 0,
   });

--- a/lib/infrastructure/crowdaction/crowdaction_repository.dart
+++ b/lib/infrastructure/crowdaction/crowdaction_repository.dart
@@ -27,6 +27,30 @@ class CrowdActionRepository implements ICrowdActionRepository {
   );
 
   @override
+  Future<Either<CrowdActionFailure, CrowdAction>> getCrowdAction(
+    String id,
+  ) async {
+    try {
+      final response = await _client.get(
+        Uri.parse(
+          '${await _settingsRepository.baseApiEndpointUrl}/v1/crowdactions/$id',
+        ),
+      );
+
+      if (response.statusCode == 200) {
+        final crowdActionDto = CrowdActionDto.fromJson(
+          jsonDecode(response.body) as Map<String, dynamic>,
+        );
+        return right(crowdActionDto.toDomain());
+      }
+
+      return left(const CrowdActionFailure.serverError());
+    } catch (ex) {
+      return left(const CrowdActionFailure.networkRequestFailed());
+    }
+  }
+
+  @override
   Future<Either<CrowdActionFailure, List<CrowdAction>>> getCrowdActions({
     int amount = 0,
   }) async {

--- a/lib/presentation/core/app_widget.dart
+++ b/lib/presentation/core/app_widget.dart
@@ -1,4 +1,3 @@
-import 'package:collaction_app/application/crowdaction/spotlight/spotlight_bloc.dart';
 import 'package:collaction_app/application/user/profile/profile_bloc.dart';
 import 'package:collaction_app/application/user/profile_tab/profile_tab_bloc.dart';
 import 'package:flutter/material.dart';
@@ -18,9 +17,6 @@ class AppWidget extends StatelessWidget {
       providers: [
         BlocProvider<AuthBloc>(
           create: (_) => getIt<AuthBloc>(),
-        ),
-        BlocProvider<SpotlightBloc>(
-          create: (_) => getIt<SpotlightBloc>(),
         ),
         BlocProvider<ProfileBloc>(
           create: (_) => getIt<ProfileBloc>()..add(GetUserProfile()),

--- a/lib/presentation/crowdaction/crowdaction_details/widgets/crowdaction_chips.dart
+++ b/lib/presentation/crowdaction/crowdaction_details/widgets/crowdaction_chips.dart
@@ -1,0 +1,48 @@
+import 'package:collaction_app/presentation/shared_widgets/accent_chip.dart';
+import 'package:collaction_app/presentation/shared_widgets/secondary_chip.dart';
+import 'package:collaction_app/presentation/themes/constants.dart';
+import 'package:flutter/material.dart';
+import 'package:shimmer/shimmer.dart';
+
+class CrowdActionChips extends StatelessWidget {
+  const CrowdActionChips({
+    Key? key,
+    this.isOpen = false,
+    required this.category,
+    this.subCategory,
+  }) : super(key: key);
+
+  final bool isOpen;
+  final String? category;
+  final String? subCategory;
+
+  @override
+  Widget build(BuildContext context) {
+    return Wrap(
+      spacing: 12.0,
+      children: [
+        if (category != null) ...[
+          ...[
+            AccentChip(
+              text: isOpen ? "Open" : "Closed",
+              color: isOpen ? kAccentColor : kPrimaryColor200,
+            ),
+            SecondaryChip(text: category!),
+            if (subCategory != null) ...[SecondaryChip(text: subCategory!)],
+          ]
+        ] else ...[
+          Shimmer.fromColors(
+            baseColor: Colors.black.withOpacity(0.1),
+            highlightColor: Colors.white.withOpacity(0.2),
+            child: const SecondaryChip(text: "Closed"),
+          ),
+          Shimmer.fromColors(
+            baseColor: Colors.black.withOpacity(0.1),
+            highlightColor: Colors.white.withOpacity(0.2),
+            child: const SecondaryChip(text: "ShimmerPlaceholder"),
+          )
+        ]
+      ],
+    );
+  }
+}

--- a/lib/presentation/crowdaction/crowdaction_details/widgets/crowdaction_details_banner.dart
+++ b/lib/presentation/crowdaction/crowdaction_details/widgets/crowdaction_details_banner.dart
@@ -1,0 +1,96 @@
+import 'package:auto_route/auto_route.dart';
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:collaction_app/domain/crowdaction/crowdaction.dart';
+import 'package:collaction_app/presentation/core/collaction_icons.dart';
+import 'package:collaction_app/presentation/shared_widgets/custom_fab.dart';
+import 'package:collaction_app/presentation/shared_widgets/image_skeleton_loader.dart';
+import 'package:collaction_app/presentation/themes/constants.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:shimmer/shimmer.dart';
+
+class CrowdActionDetailsBanner extends StatelessWidget {
+  const CrowdActionDetailsBanner({
+    Key? key,
+    required this.crowdAction,
+  }) : super(key: key);
+
+  final CrowdAction? crowdAction;
+
+  @override
+  Widget build(BuildContext context) {
+    return SliverAppBar(
+      expandedHeight: 310,
+      pinned: true,
+      backgroundColor: Colors.transparent,
+      elevation: 0,
+      automaticallyImplyLeading: false,
+      title: Row(
+        children: [
+          SizedBox(
+            width: 39,
+            height: 39,
+            child: Material(
+              type: MaterialType.button,
+              color: Colors.white,
+              borderRadius: BorderRadius.circular(20),
+              elevation: 4,
+              child: InkWell(
+                borderRadius: BorderRadius.circular(20),
+                onTap: () => context.router.pop(),
+                child: const Icon(
+                  CollactionIcons.left,
+                  color: kPrimaryColor400,
+                ),
+              ),
+            ),
+          ),
+          const Expanded(child: SizedBox()),
+        ],
+      ),
+      flexibleSpace: FlexibleSpaceBar(
+        background: Stack(
+          children: [
+            Positioned.fill(
+              child: crowdAction != null
+                  ? CachedNetworkImage(
+                      imageUrl:
+                          '${dotenv.get('BASE_STATIC_ENDPOINT_URL')}/${crowdAction!.images.banner}',
+                      placeholder: (context, url) => const ImageSkeletonLoader(
+                        height: 310,
+                      ),
+                      errorWidget: (context, url, error) =>
+                          const ImageSkeletonLoader(
+                        height: 310,
+                      ),
+                      fit: BoxFit.cover,
+                    )
+                  : Shimmer.fromColors(
+                      baseColor: Colors.black.withOpacity(0.1),
+                      highlightColor: Colors.white.withOpacity(0.2),
+                      child: const ImageSkeletonLoader(
+                        height: 310,
+                      ),
+                    ),
+            ),
+            if (crowdAction?.hasPassword ?? false) ...[
+              const Positioned(
+                bottom: 10,
+                right: 10,
+                child: CustomFAB(
+                  heroTag: 'locked',
+                  isMini: true,
+                  color: kSecondaryColor,
+                  child: Icon(
+                    CollactionIcons.lock,
+                    color: kPrimaryColor300,
+                  ),
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/crowdaction/crowdaction_details/widgets/crowdaction_title.dart
+++ b/lib/presentation/crowdaction/crowdaction_details/widgets/crowdaction_title.dart
@@ -1,0 +1,40 @@
+import 'package:collaction_app/presentation/shared_widgets/shimmers/title_shimmer_line.dart';
+import 'package:flutter/material.dart';
+import 'package:shimmer/shimmer.dart';
+
+class CrowdActionTitle extends StatelessWidget {
+  const CrowdActionTitle({
+    Key? key,
+    required this.title,
+  }) : super(key: key);
+
+  final String? title;
+
+  @override
+  Widget build(BuildContext context) {
+    return title != null
+        ? Text(
+            title!,
+            style: Theme.of(context).textTheme.headline4?.copyWith(
+                  fontWeight: FontWeight.bold,
+                  fontSize: 28,
+                ),
+          )
+        : Shimmer.fromColors(
+            baseColor: Colors.black.withOpacity(0.1),
+            highlightColor: Colors.white.withOpacity(0.2),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                TitleShimmerLine(
+                  width: MediaQuery.of(context).size.width,
+                ),
+                const SizedBox(height: 10),
+                TitleShimmerLine(
+                  width: MediaQuery.of(context).size.width * 0.4,
+                ),
+              ],
+            ),
+          );
+  }
+}

--- a/lib/presentation/crowdaction/crowdaction_details/widgets/participation_count_text.dart
+++ b/lib/presentation/crowdaction/crowdaction_details/widgets/participation_count_text.dart
@@ -1,11 +1,12 @@
 // TODO Untested! (Confirm if it works as intended)
 
+import 'package:collaction_app/application/crowdaction/crowdaction_details/crowdaction_details_bloc.dart';
+import 'package:collaction_app/presentation/shared_widgets/shimmers/title_shimmer_line.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:shimmer/shimmer.dart';
 
-import '../.../../../../../application/crowdaction/spotlight/spotlight_bloc.dart';
 import '../../../../domain/crowdaction/crowdaction.dart';
-import '../../../../presentation/shared_widgets/content_placeholder.dart';
 import '../../../../presentation/themes/constants.dart';
 
 class ParticipationCountText extends StatelessWidget {
@@ -14,42 +15,62 @@ class ParticipationCountText extends StatelessWidget {
     required this.crowdAction,
   }) : super(key: key);
 
-  final CrowdAction crowdAction;
+  final CrowdAction? crowdAction;
 
   @override
   Widget build(BuildContext context) {
-    return BlocBuilder<SpotlightBloc, SpotlightState>(
-      builder: (context, state) {
-        return state.maybeWhen(
-          initial: () {
-            final count = crowdAction.participantCount;
-            return Text(
-              "Join $count participant${count == 1 ? "" : "s"}",
-              style: Theme.of(context).textTheme.caption?.copyWith(
-                    fontSize: 14,
-                    color: kPrimaryColor300,
-                    height: 1.2,
-                  ),
-            );
-          },
-          fetchingCrowdSpotLightActions: () {
-            return const Center(
-              child: CircularProgressIndicator(color: kAccentColor),
-            );
-          },
-          spotLightCrowdActionsError: (_) {
-            return const ContentPlaceholder(textColor: Colors.white);
-          },
-          spotLightCrowdActions: (_crowdActions) {
-            final CrowdAction _updatedCrowdAction = _crowdActions.firstWhere(
-              (element) => element.id == crowdAction.id,
-            );
-            final count = _updatedCrowdAction.participantCount;
-            return Text("Join $count participant${count <= 1 ? "" : "s"}");
-          },
-          orElse: () => const SizedBox(),
-        );
-      },
+    return BlocProvider<CrowdActionDetailsBloc>.value(
+      value: BlocProvider.of<CrowdActionDetailsBloc>(context),
+      child: BlocBuilder<CrowdActionDetailsBloc, CrowdActionDetailsState>(
+        builder: (context, state) {
+          return state.when(
+            initial: () {
+              if (crowdAction != null) {
+                return participantCountText(
+                  context,
+                  crowdAction!.participantCount,
+                );
+              }
+
+              return shimmer(context);
+            },
+            loadInProgress: () {
+              if (crowdAction == null) {
+                return shimmer(context);
+              }
+
+              return participantCountText(
+                context,
+                crowdAction!.participantCount,
+              );
+            },
+            loadSuccess: (crowdAction) {
+              return participantCountText(
+                context,
+                crowdAction.participantCount,
+              );
+            },
+            loadFailure: (_) => shimmer(context),
+          );
+        },
+      ),
     );
   }
+
+  Shimmer shimmer(BuildContext context) => Shimmer.fromColors(
+        baseColor: Colors.black.withOpacity(0.1),
+        highlightColor: Colors.white.withOpacity(0.2),
+        child: TitleShimmerLine(
+          width: MediaQuery.of(context).size.width * 0.4,
+        ),
+      );
+
+  Text participantCountText(BuildContext context, int participantCount) => Text(
+        "Join $participantCount participant${participantCount == 1 ? "" : "s"}",
+        style: Theme.of(context).textTheme.caption?.copyWith(
+              fontSize: 14,
+              color: kPrimaryColor300,
+              height: 1.2,
+            ),
+      );
 }

--- a/lib/presentation/crowdaction/crowdaction_home/crowdaction_home_screen.dart
+++ b/lib/presentation/crowdaction/crowdaction_home/crowdaction_home_screen.dart
@@ -12,28 +12,24 @@ class CrowdActionHomeScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return BlocProvider<SpotlightBloc>.value(
-      value: BlocProvider.of<SpotlightBloc>(context)
-        ..add(const SpotlightEvent.getSpotLightCrowdActions()),
-      child: Scaffold(
-        body: SafeArea(
-          child: RefreshIndicator(
-            onRefresh: () async => BlocProvider.of<SpotlightBloc>(context)
-                .add(const SpotlightEvent.getSpotLightCrowdActions()),
-            color: kAccentColor,
-            child: SingleChildScrollView(
-              child: SizedBox(
-                width: double.infinity,
-                child: Column(
-                  children: const [
-                    InSpotLightHeader(),
-                    CurrentAndUpcomingLayout(),
-                    SizedBox(height: 20),
-                    ShareCollActionCard(),
-                    SizedBox(height: 20),
-                    CurrentAndUpcomingLayout(isCurrent: false)
-                  ],
-                ),
+    return Scaffold(
+      body: SafeArea(
+        child: RefreshIndicator(
+          onRefresh: () async => BlocProvider.of<SpotlightBloc>(context)
+              .add(const SpotlightEvent.getSpotLightCrowdActions()),
+          color: kAccentColor,
+          child: SingleChildScrollView(
+            child: SizedBox(
+              width: double.infinity,
+              child: Column(
+                children: const [
+                  InSpotLightHeader(),
+                  CurrentAndUpcomingLayout(),
+                  SizedBox(height: 20),
+                  ShareCollActionCard(),
+                  SizedBox(height: 20),
+                  CurrentAndUpcomingLayout(isCurrent: false)
+                ],
               ),
             ),
           ),

--- a/lib/presentation/crowdaction/crowdaction_home/widgets/in_spotlight_header.dart
+++ b/lib/presentation/crowdaction/crowdaction_home/widgets/in_spotlight_header.dart
@@ -1,10 +1,11 @@
+import 'package:collaction_app/application/crowdaction/spotlight/spotlight_bloc.dart';
 import 'package:dots_indicator/dots_indicator.dart';
 import 'package:expandable_page_view/expandable_page_view.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:intl/intl.dart';
 
-import '../../../../application/crowdaction/spotlight/spotlight_bloc.dart';
+import '../../../../infrastructure/core/injection.dart';
 import '../../../shared_widgets/content_placeholder.dart';
 import '../../../shared_widgets/crowdaction_card.dart';
 import '../../../themes/constants.dart';
@@ -33,91 +34,95 @@ class _InSpotLightHeaderState extends State<InSpotLightHeader> {
 
   @override
   Widget build(BuildContext context) {
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        return Container(
-          width: constraints.maxWidth,
-          margin: const EdgeInsets.only(bottom: 20),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              const SizedBox(
-                height: 35,
-              ),
-              Container(
-                padding: const EdgeInsets.only(left: 12, top: 8),
-                child: Text(
-                  sectionHeadingText(),
-                  style: Theme.of(context).textTheme.headline5?.copyWith(
-                        fontWeight: FontWeight.bold,
-                        color: kPrimaryColor400,
-                      ),
+    return BlocProvider(
+      create: (context) => getIt<SpotlightBloc>()
+        ..add(const SpotlightEvent.getSpotLightCrowdActions()),
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          return Container(
+            width: constraints.maxWidth,
+            margin: const EdgeInsets.only(bottom: 20),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const SizedBox(
+                  height: 35,
                 ),
-              ),
-              const SizedBox(
-                height: 10,
-              ),
-              BlocBuilder<SpotlightBloc, SpotlightState>(
-                builder: (context, state) {
-                  return state.maybeWhen(
-                    fetchingCrowdSpotLightActions: () {
-                      return const Center(
-                        child: CircularProgressIndicator(
-                          color: kAccentColor,
+                Container(
+                  padding: const EdgeInsets.only(left: 12, top: 8),
+                  child: Text(
+                    sectionHeadingText(),
+                    style: Theme.of(context).textTheme.headline5?.copyWith(
+                          fontWeight: FontWeight.bold,
+                          color: kPrimaryColor400,
                         ),
-                      );
-                    },
-                    spotLightCrowdActionsError: (_) {
-                      return const ContentPlaceholder(
-                        textColor: Colors.white,
-                      );
-                    },
-                    spotLightCrowdActions: (_pages) {
-                      return Column(
-                        children: [
-                          ExpandablePageView.builder(
-                            itemBuilder: (ctx, index) {
-                              final crowdAction = _pages[index];
-                              return CrowdActionCard(
-                                crowdAction: crowdAction,
-                              );
-                            },
-                            itemCount: _pages.length,
-                            controller: _pageController,
+                  ),
+                ),
+                const SizedBox(
+                  height: 10,
+                ),
+                BlocBuilder<SpotlightBloc, SpotlightState>(
+                  builder: (context, state) {
+                    return state.maybeWhen(
+                      fetchingCrowdSpotLightActions: () {
+                        return const Center(
+                          child: CircularProgressIndicator(
+                            color: kAccentColor,
                           ),
-                          const SizedBox(height: 5),
-                          Row(
-                            children: [
-                              const Expanded(child: SizedBox()),
-                              DotsIndicator(
-                                position: _currentPage,
-                                dotsCount: _pages.length,
-                                decorator: const DotsDecorator(
-                                  activeColor: kAccentColor,
-                                  color: Color(0xFFCCCCCC),
-                                  size: Size(12.0, 12.0),
-                                  activeSize: Size(12.0, 12.0),
-                                  spacing: EdgeInsets.all(8.0),
+                        );
+                      },
+                      spotLightCrowdActionsError: (_) {
+                        return const ContentPlaceholder(
+                          textColor: Colors.white,
+                        );
+                      },
+                      spotLightCrowdActions: (_pages) {
+                        return Column(
+                          children: [
+                            ExpandablePageView.builder(
+                              itemBuilder: (ctx, index) {
+                                final crowdAction = _pages[index];
+                                return CrowdActionCard(
+                                  crowdAction: crowdAction,
+                                );
+                              },
+                              itemCount: _pages.length,
+                              controller: _pageController,
+                            ),
+                            const SizedBox(height: 5),
+                            Row(
+                              children: [
+                                const Expanded(child: SizedBox()),
+                                DotsIndicator(
+                                  position: _currentPage,
+                                  dotsCount: _pages.length,
+                                  decorator: const DotsDecorator(
+                                    activeColor: kAccentColor,
+                                    color: Color(0xFFCCCCCC),
+                                    size: Size(12.0, 12.0),
+                                    activeSize: Size(12.0, 12.0),
+                                    spacing: EdgeInsets.all(8.0),
+                                  ),
                                 ),
-                              ),
-                              const Expanded(child: SizedBox()),
-                            ],
-                          ),
-                        ],
-                      );
-                    },
-                    orElse: () => const SizedBox(),
-                  );
-                },
-              ),
-              const SizedBox(
-                height: 20,
-              ),
-            ],
-          ),
-        );
-      },
+                                const Expanded(child: SizedBox()),
+                              ],
+                            ),
+                          ],
+                        );
+                      },
+                      orElse: () => const SizedBox(),
+                    );
+                  },
+                ),
+                const SizedBox(
+                  height: 20,
+                ),
+              ],
+            ),
+          );
+        },
+      ),
     );
   }
 

--- a/lib/presentation/home/widgets/current_upcoming_layout.dart
+++ b/lib/presentation/home/widgets/current_upcoming_layout.dart
@@ -1,4 +1,5 @@
 import 'package:auto_route/auto_route.dart';
+import 'package:collaction_app/infrastructure/core/injection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
@@ -24,74 +25,79 @@ class CurrentAndUpcomingLayout extends StatefulWidget {
 class _CurrentAndUpcomingLayoutState extends State<CurrentAndUpcomingLayout> {
   @override
   Widget build(BuildContext context) {
-    // TODO: Refactor to not use SpotlightBloc, we should generalize to only have ONE crowdaction bloc!!!!!
-    return BlocBuilder<SpotlightBloc, SpotlightState>(
-      builder: (ctx, state) => LayoutBuilder(
-        builder: (context, constraints) {
-          return SizedBox(
-            width: constraints.maxWidth,
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                Container(
-                  margin: const EdgeInsets.only(left: 10, right: 10),
-                  child: Row(
-                    crossAxisAlignment: CrossAxisAlignment.baseline,
-                    textBaseline: TextBaseline.alphabetic,
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: [
-                      Text(
-                        widget.isCurrent ? 'Currently running' : 'Upcoming',
-                        style: Theme.of(context).textTheme.headline5?.copyWith(
-                              fontWeight: FontWeight.bold,
-                              color: kPrimaryColor400,
-                            ),
-                      ),
-                      TextButton(
-                        onPressed: () => context.router.push(
-                          widget.isCurrent
-                              ? const CrowdActionBrowseRoute()
-                              : const CrowdActionBrowseRoute(),
+    return BlocProvider<SpotlightBloc>(
+      create: (context) => getIt<SpotlightBloc>()
+        ..add(const SpotlightEvent.getSpotLightCrowdActions()),
+      child: BlocBuilder<SpotlightBloc, SpotlightState>(
+        builder: (ctx, state) => LayoutBuilder(
+          builder: (context, constraints) {
+            return SizedBox(
+              width: constraints.maxWidth,
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Container(
+                    margin: const EdgeInsets.only(left: 10, right: 10),
+                    child: Row(
+                      crossAxisAlignment: CrossAxisAlignment.baseline,
+                      textBaseline: TextBaseline.alphabetic,
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: [
+                        Text(
+                          widget.isCurrent ? 'Currently running' : 'Upcoming',
+                          style:
+                              Theme.of(context).textTheme.headline5?.copyWith(
+                                    fontWeight: FontWeight.bold,
+                                    color: kPrimaryColor400,
+                                  ),
                         ),
-                        child: const Text(
-                          'View all',
-                          textAlign: TextAlign.center,
-                          style: TextStyle(
-                            fontWeight: FontWeight.w700,
-                            fontSize: 15.0,
-                            color: kAccentColor,
+                        TextButton(
+                          onPressed: () => context.router.push(
+                            widget.isCurrent
+                                ? const CrowdActionBrowseRoute()
+                                : const CrowdActionBrowseRoute(),
+                          ),
+                          child: const Text(
+                            'View all',
+                            textAlign: TextAlign.center,
+                            style: TextStyle(
+                              fontWeight: FontWeight.w700,
+                              fontSize: 15.0,
+                              color: kAccentColor,
+                            ),
                           ),
                         ),
-                      ),
-                    ],
-                  ),
-                ),
-                state.maybeMap(
-                  fetchingCrowdSpotLightActions: (_) => const Center(
-                    child: CircularProgressIndicator(
-                      color: kAccentColor,
+                      ],
                     ),
                   ),
-                  spotLightCrowdActions: (fetchedData) => Column(
-                    children: [
-                      ...fetchedData.crowdActions
-                          .map(
-                            (crowdAction) => MicroCrowdActionCard(crowdAction),
-                          )
-                          .toList(),
-                    ],
+                  state.maybeMap(
+                    fetchingCrowdSpotLightActions: (_) => const Center(
+                      child: CircularProgressIndicator(
+                        color: kAccentColor,
+                      ),
+                    ),
+                    spotLightCrowdActions: (fetchedData) => Column(
+                      children: [
+                        ...fetchedData.crowdActions
+                            .map(
+                              (crowdAction) =>
+                                  MicroCrowdActionCard(crowdAction),
+                            )
+                            .toList(),
+                      ],
+                    ),
+                    spotLightCrowdActionsError: (failure) =>
+                        const ContentPlaceholder(
+                      textColor: Colors.black,
+                    ),
+                    orElse: () => const SizedBox(),
                   ),
-                  spotLightCrowdActionsError: (failure) =>
-                      const ContentPlaceholder(
-                    textColor: Colors.black,
-                  ),
-                  orElse: () => const SizedBox(),
-                ),
-              ],
-            ),
-          );
-        },
+                ],
+              ),
+            );
+          },
+        ),
       ),
     );
   }

--- a/lib/presentation/shared_widgets/commitments/commitment_card_list.dart
+++ b/lib/presentation/shared_widgets/commitments/commitment_card_list.dart
@@ -1,12 +1,13 @@
 import 'package:collaction_app/application/participation/participation_bloc.dart';
 import 'package:collaction_app/domain/crowdaction/crowdaction.dart';
+import 'package:collaction_app/presentation/shared_widgets/shimmers/commitment_card_shimmer.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 import 'commitment_card.dart';
 
 class CommitmentCardList extends StatefulWidget {
-  final List<CommitmentOption> commitmentOptions;
+  final List<CommitmentOption>? commitmentOptions;
   final List<CommitmentOption> selectedCommitments;
 
   /// Widget for easily creating a list of CommitmentCard(s)
@@ -25,6 +26,19 @@ class _CommitmentCardListState extends State<CommitmentCardList> {
   Widget build(BuildContext context) {
     return BlocBuilder<ParticipationBloc, ParticipationState>(
       builder: (context, state) {
+        if (widget.commitmentOptions == null) {
+          return ListView(
+            shrinkWrap: true,
+            padding: const EdgeInsets.symmetric(horizontal: 20),
+            physics: const BouncingScrollPhysics(),
+            children: const [
+              CommitmentCardShimmer(),
+              CommitmentCardShimmer(),
+              CommitmentCardShimmer(),
+            ],
+          );
+        }
+
         bool isParticipating = false;
 
         state.mapOrNull(
@@ -35,7 +49,7 @@ class _CommitmentCardListState extends State<CommitmentCardList> {
           padding: const EdgeInsets.symmetric(horizontal: 20),
           physics: const BouncingScrollPhysics(),
           itemBuilder: (ctx, index) {
-            final option = widget.commitmentOptions[index];
+            final option = widget.commitmentOptions![index];
             return CommitmentCard(
               key: Key(option.id),
               commitment: option,
@@ -45,7 +59,7 @@ class _CommitmentCardListState extends State<CommitmentCardList> {
               deactivated: isParticipating || isBlocked(option),
             );
           },
-          itemCount: widget.commitmentOptions.length,
+          itemCount: widget.commitmentOptions!.length,
           shrinkWrap: true,
         );
       },

--- a/lib/presentation/shared_widgets/shimmers/commitment_card_shimmer.dart
+++ b/lib/presentation/shared_widgets/shimmers/commitment_card_shimmer.dart
@@ -1,0 +1,74 @@
+import 'package:collaction_app/presentation/core/collaction_icons.dart';
+import 'package:collaction_app/presentation/shared_widgets/shimmers/title_shimmer_line.dart';
+import 'package:collaction_app/presentation/themes/constants.dart';
+import 'package:flutter/material.dart';
+import 'package:shimmer/shimmer.dart';
+
+class CommitmentCardShimmer extends StatelessWidget {
+  const CommitmentCardShimmer();
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(20.0),
+        color: kSecondaryColor,
+        border: Border.all(color: kPrimaryColor0),
+      ),
+      margin: const EdgeInsets.symmetric(vertical: 5.0),
+      padding: const EdgeInsets.all(10.0),
+      child: Row(
+        children: [
+          Container(
+            padding: const EdgeInsets.all(15.0),
+            decoration: const BoxDecoration(
+              shape: BoxShape.circle,
+              color: kSecondaryColor,
+            ),
+            alignment: Alignment.center,
+            child: Shimmer.fromColors(
+              baseColor: kSecondaryTransparent,
+              highlightColor: kAlmostTransparent,
+              child: const Icon(
+                CollactionIcons.commitment,
+                color: kPrimaryColor0,
+                size: 30,
+              ),
+            ),
+          ),
+          const Spacer(),
+          Container(
+            width: MediaQuery.of(context).size.width * 0.5,
+            constraints: const BoxConstraints(
+              maxHeight: 70,
+            ),
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Shimmer.fromColors(
+                  baseColor: Colors.black.withOpacity(0.1),
+                  highlightColor: Colors.white.withOpacity(0.2),
+                  child: TitleShimmerLine(
+                    width: MediaQuery.of(context).size.width * 0.4,
+                  ),
+                ),
+                const SizedBox(height: 5),
+                Shimmer.fromColors(
+                  baseColor: Colors.black.withOpacity(0.1),
+                  highlightColor: Colors.white.withOpacity(0.2),
+                  child: TitleShimmerLine(
+                    height: 18,
+                    width: MediaQuery.of(context).size.width * 0.5,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const Spacer(),
+          const SizedBox(height: 32, width: 32),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/presentation/shared_widgets/shimmers/title_shimmer_line.dart
+++ b/lib/presentation/shared_widgets/shimmers/title_shimmer_line.dart
@@ -1,0 +1,24 @@
+import 'package:collaction_app/presentation/themes/constants.dart';
+import 'package:flutter/material.dart';
+
+class TitleShimmerLine extends StatelessWidget {
+  final double width;
+  final double height;
+
+  const TitleShimmerLine({
+    required this.width,
+    this.height = 24,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: width,
+      height: height,
+      decoration: BoxDecoration(
+        color: kSecondaryTransparent,
+        borderRadius: BorderRadius.circular(10),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
CrowdActionDetailsScreen now supports either CrowdAction or CrowdAction ID to fetch/display data. Also is separated completely from SpotlightBloc, and has its own BLoC. All Widgets now have Shimmers for loading where applicable.