### PR TITLE
fix(profile): change on logout

### DIFF
--- a/.github/scripts/coverage_gen.sh
+++ b/.github/scripts/coverage_gen.sh
@@ -1,7 +1,10 @@
 #!/bin/sh
 file=test/coverage_helper_test.dart
 touch file
-echo "// Helper file to make coverage report for all dart files\n" >> $file
-echo "// ignore_for_file: unused_import" >> $file
-find lib -type f \( -iname "*.dart" ! -iname "*.g.dart" ! -iname "*.gr.dart" ! -iname "*.freezed.dart" ! -iname "generated_plugin_registrant.dart" ! -iname "*_state.dart" ! -iname "*_event.dart" \) | cut -c 4- | sort | awk -v package="$1" '{printf "import '\''package:collaction_app%s%s'\'';\n", package, $1}' >> $file
-echo "void main(){}" >> $file
+
+{
+  printf "// Helper file to make coverage report for all dart files\n"
+  echo "// ignore_for_file: unused_import"
+  find lib -type f \( -iname "*.dart" ! -iname "generated_plugin_registrant.dart" \) -print0 | xargs -0 grep -L "^part of" | cut -c 4- | sort | awk -v package="$1" '{printf "import '\''package:collaction_app%s%s'\'';\n", package, $1}'
+  echo "void main(){}"
+} >>$file

--- a/lib/core/config/network_config.dart
+++ b/lib/core/config/network_config.dart
@@ -1,0 +1,32 @@
+part of '../core.dart';
+
+/// Manage all url creation and building
+// ignore_for_file: avoid_classes_with_only_static_members
+class NetworkConfig {
+  // base static url
+  static final _baseStaticUrl = dotenv.get('BASE_STATIC_ENDPOINT_URL');
+
+  // User profile avatar url
+  static String? userAvatar(UserProfile? userProfile) {
+    if (userProfile?.profile.avatar != null) {
+      return '$_baseStaticUrl/${userProfile?.profile.avatar}';
+    }
+
+    return null;
+  }
+
+  // Crowdaction banner url
+  static String crowdActionBanner(CrowdAction? crowdAction) {
+    return '$_baseStaticUrl/${crowdAction?.images.banner}';
+  }
+
+  // Crowdaction card url
+  static String crowdActionCard(CrowdAction? crowdAction) {
+    return '$_baseStaticUrl/${crowdAction?.images.card}';
+  }
+
+  // Participation avatar url
+  static String participationAvatar(Participation? participation) {
+    return '$_baseStaticUrl/${participation?.avatar}';
+  }
+}

--- a/lib/core/config/network_config.dart
+++ b/lib/core/config/network_config.dart
@@ -2,34 +2,6 @@ part of '../core.dart';
 
 /// Manage all url creation and building
 // base static url
-final _baseStaticUrl = dotenv.get('BASE_STATIC_ENDPOINT_URL');
+final baseStaticUrl = dotenv.get('BASE_STATIC_ENDPOINT_URL');
 
-extension UserProfileUrlX on UserProfile? {
-  // User profile avatar url
-  String? get avatarUrl {
-    if (this?.profile.avatar != null) {
-      return '$_baseStaticUrl/${this?.profile.avatar}';
-    }
-
-    return null;
-  }
-}
-
-extension CrowdActionUrlX on CrowdAction? {
-  // Crowdaction banner url
-  String get bannerUrl {
-    return '$_baseStaticUrl/${this?.images.banner}';
-  }
-
-  // Crowdaction card url
-  String get cardUrl {
-    return '$_baseStaticUrl/${this?.images.card}';
-  }
-}
-
-extension ParticipationUrlX on Participation? {
-  // Participation avatar url
-  String get avatarUrl {
-    return '$_baseStaticUrl/${this?.avatar}';
-  }
-}
+final nullStaticUrl = '$baseStaticUrl/${null}';

--- a/lib/core/config/network_config.dart
+++ b/lib/core/config/network_config.dart
@@ -1,32 +1,35 @@
 part of '../core.dart';
 
 /// Manage all url creation and building
-// ignore_for_file: avoid_classes_with_only_static_members
-class NetworkConfig {
-  // base static url
-  static final _baseStaticUrl = dotenv.get('BASE_STATIC_ENDPOINT_URL');
+// base static url
+final _baseStaticUrl = dotenv.get('BASE_STATIC_ENDPOINT_URL');
 
+extension UserProfileUrlX on UserProfile? {
   // User profile avatar url
-  static String? userAvatar(UserProfile? userProfile) {
-    if (userProfile?.profile.avatar != null) {
-      return '$_baseStaticUrl/${userProfile?.profile.avatar}';
+  String? get avatarUrl {
+    if (this?.profile.avatar != null) {
+      return '$_baseStaticUrl/${this?.profile.avatar}';
     }
 
     return null;
   }
+}
 
+extension CrowdActionUrlX on CrowdAction? {
   // Crowdaction banner url
-  static String crowdActionBanner(CrowdAction? crowdAction) {
-    return '$_baseStaticUrl/${crowdAction?.images.banner}';
+  String get bannerUrl {
+    return '$_baseStaticUrl/${this?.images.banner}';
   }
 
   // Crowdaction card url
-  static String crowdActionCard(CrowdAction? crowdAction) {
-    return '$_baseStaticUrl/${crowdAction?.images.card}';
+  String get cardUrl {
+    return '$_baseStaticUrl/${this?.images.card}';
   }
+}
 
+extension ParticipationUrlX on Participation? {
   // Participation avatar url
-  static String participationAvatar(Participation? participation) {
-    return '$_baseStaticUrl/${participation?.avatar}';
+  String get avatarUrl {
+    return '$_baseStaticUrl/${this?.avatar}';
   }
 }

--- a/lib/core/core.dart
+++ b/lib/core/core.dart
@@ -1,0 +1,7 @@
+import 'package:collaction_app/domain/crowdaction/crowdaction.dart';
+import 'package:collaction_app/domain/profile/user_profile.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+
+import '../domain/participation/participation.dart';
+
+part 'config/network.config.dart';

--- a/lib/core/core.dart
+++ b/lib/core/core.dart
@@ -1,7 +1,3 @@
-import 'package:collaction_app/domain/crowdaction/crowdaction.dart';
-import 'package:collaction_app/domain/profile/user_profile.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
-
-import '../domain/participation/participation.dart';
 
 part 'config/network_config.dart';

--- a/lib/core/core.dart
+++ b/lib/core/core.dart
@@ -4,4 +4,4 @@ import 'package:flutter_dotenv/flutter_dotenv.dart';
 
 import '../domain/participation/participation.dart';
 
-part 'config/network.config.dart';
+part 'config/network_config.dart';

--- a/lib/domain/crowdaction/crowdaction.dart
+++ b/lib/domain/crowdaction/crowdaction.dart
@@ -1,3 +1,4 @@
+import 'package:collaction_app/core/core.dart';
 import 'package:flutter/material.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
@@ -50,6 +51,12 @@ class CrowdAction with _$CrowdAction {
           : isWaiting
               ? 'Starting soon'
               : 'Finished';
+
+  // Crowdaction banner url
+  String get bannerUrl => '$baseStaticUrl/${images.banner}';
+
+  // Crowdaction card url
+  String get cardUrl => '$baseStaticUrl/${images.card}';
 }
 
 @freezed

--- a/lib/domain/participation/participation.dart
+++ b/lib/domain/participation/participation.dart
@@ -1,3 +1,4 @@
+import 'package:collaction_app/core/core.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'participation.freezed.dart';
@@ -16,4 +17,7 @@ class Participation with _$Participation {
     required DateTime joinDate,
     required int dailyCheckIns,
   }) = _Participation;
+
+  // Participation avatar url
+  String get avatarUrl => '$baseStaticUrl/$avatar';
 }

--- a/lib/domain/profile/user_profile.dart
+++ b/lib/domain/profile/user_profile.dart
@@ -1,3 +1,4 @@
+import 'package:collaction_app/core/core.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 import '../user/user.dart';
@@ -13,4 +14,7 @@ class UserProfile with _$UserProfile {
     required User user,
     required Profile profile,
   }) = _UserProfile;
+
+  // User profile avatar url
+  String? get avatarUrl => '$baseStaticUrl/${profile.avatar}';
 }

--- a/lib/presentation/auth/auth_screen.dart
+++ b/lib/presentation/auth/auth_screen.dart
@@ -39,83 +39,77 @@ class _AuthPageState extends State<AuthPage> {
 
   @override
   Widget build(BuildContext context) {
-    return BlocProvider<ProfileBloc>(
-      create: (context) => getIt<ProfileBloc>(),
-      child: BlocProvider(
-        create: (context) => getIt<AuthBloc>(),
-        child: BlocListener<AuthBloc, AuthState>(
-          listener: (context, state) {
-            state.maybeMap(
-              smsCodeSent: (_) => _toPage(1),
-              loggedIn: (loggedInState) {
-                if (loggedInState.isNewUser) {
-                  // TODO: We need to improve this flow on the backend - this makes sure profile is created
-                  BlocProvider.of<ProfileBloc>(context).add(GetUserProfile());
-                  _toPage(2);
-                } else {
-                  _authDone(context);
-                }
-              },
-              authError: (authError) => context.showErrorSnack(
-                authError.failure.map(
-                  serverError: (_) => "Server Error",
-                  invalidPhone: (_) => "Invalid Phone",
-                  verificationFailed: (_) => "Verification Failed",
-                  networkRequestFailed: (_) => "No Internet connection",
-                  invalidSmsCode: (_) => "Invalid SMS Code",
-                ),
-              ),
-              photoUpdateDone: (_) => _authDone(context),
-              orElse: () {},
-            );
+    return BlocListener<AuthBloc, AuthState>(
+      listener: (context, state) {
+        state.maybeMap(
+          smsCodeSent: (_) => _toPage(1),
+          loggedIn: (loggedInState) {
+            if (loggedInState.isNewUser) {
+              // TODO: We need to improve this flow on the backend - this makes sure profile is created
+              BlocProvider.of<ProfileBloc>(context).add(GetUserProfile());
+              _toPage(2);
+            } else {
+              _authDone(context);
+            }
           },
-          child: Scaffold(
-            resizeToAvoidBottomInset: true,
-            appBar: _currentPage == 0
-                ? const CustomAppBar(closable: true)
-                : AppBar(backgroundColor: Colors.transparent, elevation: 0.0),
-            body: SafeArea(
-              child: SingleChildScrollView(
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 23.0),
-                  child: Column(
-                    children: [
-                      SizedBox(
-                        height: 520.0,
-                        child: PageView(
-                          controller: _pageController,
-                          physics: const NeverScrollableScrollPhysics(),
-                          children: [
-                            const VerifyPhonePage(),
-                            const EnterVerificationCode(),
-                            EnterUserName(
-                              onDone: (fName) {
-                                _toPage(3);
+          authError: (authError) => context.showErrorSnack(
+            authError.failure.map(
+              serverError: (_) => "Server Error",
+              invalidPhone: (_) => "Invalid Phone",
+              verificationFailed: (_) => "Verification Failed",
+              networkRequestFailed: (_) => "No Internet connection",
+              invalidSmsCode: (_) => "Invalid SMS Code",
+            ),
+          ),
+          photoUpdateDone: (_) => _authDone(context),
+          orElse: () {},
+        );
+      },
+      child: Scaffold(
+        resizeToAvoidBottomInset: true,
+        appBar: _currentPage == 0
+            ? const CustomAppBar(closable: true)
+            : AppBar(backgroundColor: Colors.transparent, elevation: 0.0),
+        body: SafeArea(
+          child: SingleChildScrollView(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 23.0),
+              child: Column(
+                children: [
+                  SizedBox(
+                    height: 520.0,
+                    child: PageView(
+                      controller: _pageController,
+                      physics: const NeverScrollableScrollPhysics(),
+                      children: [
+                        const VerifyPhonePage(),
+                        const EnterVerificationCode(),
+                        EnterUserName(
+                          onDone: (fName) {
+                            _toPage(3);
 
-                                setState(() {
-                                  _displayDots = false;
-                                  fullName = fName;
-                                });
-                              },
-                            ),
-                            SelectProfilePhoto(onSkip: () => _authDone(context))
-                          ],
+                            setState(() {
+                              _displayDots = false;
+                              fullName = fName;
+                            });
+                          },
                         ),
-                      ),
-                      if (_displayDots)
-                        DotsIndicator(
-                          position: _currentPage % 3,
-                          dotsCount: 3,
-                          decorator: const DotsDecorator(
-                            activeColor: kAccentColor,
-                            color: Color(0xFFCCCCCC),
-                            size: Size(12.0, 12.0),
-                            activeSize: Size(12.0, 12.0),
-                          ),
-                        )
-                    ],
+                        SelectProfilePhoto(onSkip: () => _authDone(context))
+                      ],
+                    ),
                   ),
-                ),
+                  if (_displayDots)
+                    DotsIndicator(
+                      position: _currentPage % 3,
+                      dotsCount: 3,
+                      decorator: const DotsDecorator(
+                        activeColor: kAccentColor,
+                        color: Color(0xFFCCCCCC),
+                        size: Size(12.0, 12.0),
+                        activeSize: Size(12.0, 12.0),
+                      ),
+                    )
+                ],
               ),
             ),
           ),

--- a/lib/presentation/auth/auth_screen.dart
+++ b/lib/presentation/auth/auth_screen.dart
@@ -5,7 +5,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 import '../../application/auth/auth_bloc.dart';
-import '../../infrastructure/core/injection.dart';
 import '../routes/app_routes.gr.dart';
 import '../shared_widgets/custom_app_bars/custom_appbar.dart';
 import '../themes/constants.dart';

--- a/lib/presentation/crowdaction/crowdaction_details/widgets/crowdaction_details_banner.dart
+++ b/lib/presentation/crowdaction/crowdaction_details/widgets/crowdaction_details_banner.dart
@@ -1,12 +1,12 @@
 import 'package:auto_route/auto_route.dart';
 import 'package:cached_network_image/cached_network_image.dart';
+import 'package:collaction_app/core/core.dart';
 import 'package:collaction_app/domain/crowdaction/crowdaction.dart';
 import 'package:collaction_app/presentation/core/collaction_icons.dart';
 import 'package:collaction_app/presentation/shared_widgets/custom_fab.dart';
 import 'package:collaction_app/presentation/shared_widgets/image_skeleton_loader.dart';
 import 'package:collaction_app/presentation/themes/constants.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:shimmer/shimmer.dart';
 
 class CrowdActionDetailsBanner extends StatelessWidget {
@@ -54,8 +54,7 @@ class CrowdActionDetailsBanner extends StatelessWidget {
             Positioned.fill(
               child: crowdAction != null
                   ? CachedNetworkImage(
-                      imageUrl:
-                          '${dotenv.get('BASE_STATIC_ENDPOINT_URL')}/${crowdAction!.images.banner}',
+                      imageUrl: NetworkConfig.crowdActionBanner(crowdAction),
                       placeholder: (context, url) => const ImageSkeletonLoader(
                         height: 310,
                       ),

--- a/lib/presentation/crowdaction/crowdaction_details/widgets/crowdaction_details_banner.dart
+++ b/lib/presentation/crowdaction/crowdaction_details/widgets/crowdaction_details_banner.dart
@@ -54,7 +54,7 @@ class CrowdActionDetailsBanner extends StatelessWidget {
             Positioned.fill(
               child: crowdAction != null
                   ? CachedNetworkImage(
-                      imageUrl: crowdAction.bannerUrl,
+                      imageUrl: crowdAction?.bannerUrl ?? nullStaticUrl,
                       placeholder: (context, url) => const ImageSkeletonLoader(
                         height: 310,
                       ),

--- a/lib/presentation/crowdaction/crowdaction_details/widgets/crowdaction_details_banner.dart
+++ b/lib/presentation/crowdaction/crowdaction_details/widgets/crowdaction_details_banner.dart
@@ -54,7 +54,7 @@ class CrowdActionDetailsBanner extends StatelessWidget {
             Positioned.fill(
               child: crowdAction != null
                   ? CachedNetworkImage(
-                      imageUrl: NetworkConfig.crowdActionBanner(crowdAction),
+                      imageUrl: crowdAction.bannerUrl,
                       placeholder: (context, url) => const ImageSkeletonLoader(
                         height: 310,
                       ),

--- a/lib/presentation/crowdaction/crowdaction_participants/crowdaction_participants_screen.dart
+++ b/lib/presentation/crowdaction/crowdaction_participants/crowdaction_participants_screen.dart
@@ -1,10 +1,10 @@
 import 'package:auto_route/auto_route.dart';
 import 'package:collaction_app/application/crowdaction/crowdaction_participants/crowdaction_participants_bloc.dart';
+import 'package:collaction_app/core/core.dart';
 import 'package:collaction_app/domain/participation/participation.dart';
 import 'package:collaction_app/infrastructure/core/injection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:infinite_scroll_pagination/infinite_scroll_pagination.dart';
 
 import '../../themes/constants.dart';
@@ -92,7 +92,7 @@ class CrowdActionParticipantsPage extends StatelessWidget {
                 itemBuilder: (context, participation, index) => ListTile(
                   leading: CircleAvatar(
                     foregroundImage: NetworkImage(
-                      '${dotenv.get('BASE_STATIC_ENDPOINT_URL')}/${participation.avatar}',
+                      NetworkConfig.participationAvatar(participation),
                     ),
                     backgroundImage: const AssetImage(
                       'assets/images/default_avatar.png',

--- a/lib/presentation/crowdaction/crowdaction_participants/crowdaction_participants_screen.dart
+++ b/lib/presentation/crowdaction/crowdaction_participants/crowdaction_participants_screen.dart
@@ -1,6 +1,5 @@
 import 'package:auto_route/auto_route.dart';
 import 'package:collaction_app/application/crowdaction/crowdaction_participants/crowdaction_participants_bloc.dart';
-import 'package:collaction_app/core/core.dart';
 import 'package:collaction_app/domain/participation/participation.dart';
 import 'package:collaction_app/infrastructure/core/injection.dart';
 import 'package:flutter/material.dart';

--- a/lib/presentation/crowdaction/crowdaction_participants/crowdaction_participants_screen.dart
+++ b/lib/presentation/crowdaction/crowdaction_participants/crowdaction_participants_screen.dart
@@ -92,7 +92,7 @@ class CrowdActionParticipantsPage extends StatelessWidget {
                 itemBuilder: (context, participation, index) => ListTile(
                   leading: CircleAvatar(
                     foregroundImage: NetworkImage(
-                      NetworkConfig.participationAvatar(participation),
+                      participation.avatarUrl,
                     ),
                     backgroundImage: const AssetImage(
                       'assets/images/default_avatar.png',

--- a/lib/presentation/shared_widgets/micro_crowdaction_card.dart
+++ b/lib/presentation/shared_widgets/micro_crowdaction_card.dart
@@ -1,6 +1,5 @@
 import 'package:auto_route/auto_route.dart';
 import 'package:cached_network_image/cached_network_image.dart';
-import 'package:collaction_app/core/core.dart';
 import 'package:flutter/material.dart';
 
 import '../../domain/crowdaction/crowdaction.dart';

--- a/lib/presentation/shared_widgets/micro_crowdaction_card.dart
+++ b/lib/presentation/shared_widgets/micro_crowdaction_card.dart
@@ -1,7 +1,7 @@
 import 'package:auto_route/auto_route.dart';
 import 'package:cached_network_image/cached_network_image.dart';
+import 'package:collaction_app/core/core.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_dotenv/flutter_dotenv.dart';
 
 import '../../domain/crowdaction/crowdaction.dart';
 import '../home/widgets/password_modal.dart';
@@ -48,7 +48,7 @@ class MicroCrowdActionCard extends StatelessWidget {
                   borderRadius: BorderRadius.circular(15),
                   image: DecorationImage(
                     image: CachedNetworkImageProvider(
-                      '${dotenv.get('BASE_STATIC_ENDPOINT_URL')}/${crowdAction.images.card}',
+                      NetworkConfig.crowdActionCard(crowdAction),
                       errorListener: () {},
                     ),
                     fit: BoxFit.cover,

--- a/lib/presentation/shared_widgets/micro_crowdaction_card.dart
+++ b/lib/presentation/shared_widgets/micro_crowdaction_card.dart
@@ -48,7 +48,7 @@ class MicroCrowdActionCard extends StatelessWidget {
                   borderRadius: BorderRadius.circular(15),
                   image: DecorationImage(
                     image: CachedNetworkImageProvider(
-                      NetworkConfig.crowdActionCard(crowdAction),
+                      crowdAction.cardUrl,
                       errorListener: () {},
                     ),
                     fit: BoxFit.cover,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -140,21 +140,21 @@ packages:
       name: cached_network_image
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.2.1"
+    version: "3.2.2"
   cached_network_image_platform_interface:
     dependency: transitive
     description:
       name: cached_network_image_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "2.0.0"
   cached_network_image_web:
     dependency: transitive
     description:
       name: cached_network_image_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "1.0.2"
   characters:
     dependency: transitive
     description:
@@ -253,13 +253,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.0.2"
-  cupertino_icons:
-    dependency: "direct main"
-    description:
-      name: cupertino_icons
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.5"
   dart_jsonwebtoken:
     dependency: transitive
     description:
@@ -344,27 +337,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "6.1.4"
-  firebase_analytics:
-    dependency: "direct main"
-    description:
-      name: firebase_analytics
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "9.3.8"
-  firebase_analytics_platform_interface:
-    dependency: transitive
-    description:
-      name: firebase_analytics_platform_interface
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "3.3.7"
-  firebase_analytics_web:
-    dependency: transitive
-    description:
-      name: firebase_analytics_web
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.4.2+7"
   firebase_auth:
     dependency: "direct main"
     description:
@@ -428,27 +400,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.3.0"
-  firebase_remote_config:
-    dependency: "direct main"
-    description:
-      name: firebase_remote_config
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.0.20"
-  firebase_remote_config_platform_interface:
-    dependency: transitive
-    description:
-      name: firebase_remote_config_platform_interface
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.1.19"
-  firebase_remote_config_web:
-    dependency: transitive
-    description:
-      name: firebase_remote_config_web
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.1.8"
   fixnum:
     dependency: transitive
     description:
@@ -681,6 +632,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.3"
+  ionicons:
+    dependency: "direct main"
+    description:
+      name: ionicons
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.2.1"
   js:
     dependency: transitive
     description:
@@ -731,26 +689,19 @@ packages:
     source: hosted
     version: "0.1.5"
   meta:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.0"
   mime:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: mime
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.2"
-  mockito:
-    dependency: "direct dev"
-    description:
-      name: mockito
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "5.3.2"
   mocktail:
     dependency: "direct main"
     description:
@@ -765,13 +716,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.0"
-  network_image_mock:
-    dependency: "direct dev"
-    description:
-      name: network_image_mock
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.1.1"
   node_preamble:
     dependency: transitive
     description:
@@ -799,42 +743,14 @@ packages:
       name: package_info_plus
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.3+1"
-  package_info_plus_linux:
-    dependency: transitive
-    description:
-      name: package_info_plus_linux
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.5"
-  package_info_plus_macos:
-    dependency: transitive
-    description:
-      name: package_info_plus_macos
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.0"
+    version: "3.0.1"
   package_info_plus_platform_interface:
     dependency: transitive
     description:
       name: package_info_plus_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
-  package_info_plus_web:
-    dependency: transitive
-    description:
-      name: package_info_plus_web
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.6"
-  package_info_plus_windows:
-    dependency: transitive
-    description:
-      name: package_info_plus_windows
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.1.0"
+    version: "2.0.1"
   path:
     dependency: transitive
     description:
@@ -988,42 +904,14 @@ packages:
       name: share_plus
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.5.3"
-  share_plus_linux:
-    dependency: transitive
-    description:
-      name: share_plus_linux
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "3.0.1"
-  share_plus_macos:
-    dependency: transitive
-    description:
-      name: share_plus_macos
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "3.0.1"
+    version: "6.0.1"
   share_plus_platform_interface:
     dependency: transitive
     description:
       name: share_plus_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.1"
-  share_plus_web:
-    dependency: transitive
-    description:
-      name: share_plus_web
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "3.1.0"
-  share_plus_windows:
-    dependency: transitive
-    description:
-      name: share_plus_windows
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "3.0.1"
+    version: "3.1.2"
   shared_preferences:
     dependency: "direct main"
     description:
@@ -1408,5 +1296,5 @@ packages:
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=2.18.0 <3.0.0"
-  flutter: ">=3.3.0-0"
+  dart: ">=2.18.2 <3.0.0"
+  flutter: ">=3.3.0"

--- a/test/core/config/network.config_test.dart
+++ b/test/core/config/network.config_test.dart
@@ -1,0 +1,146 @@
+import 'package:collaction_app/core/core.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../utils/crowdaction.fixtures.dart';
+import '../../utils/participation.fixtures.dart';
+import '../../utils/user.fixtures.dart';
+
+void main() {
+  const baseStaticUrl = 'https://staticurl.com/';
+
+  setUpAll(() {
+    dotenv.testLoad(
+      fileInput: '''
+                BASE_STATIC_ENDPOINT_URL=$baseStaticUrl\t
+                ''',
+    );
+  });
+
+  group('[userAvatar]', () {
+    test(
+        'should return user avatar url '
+        'when the user profile is not null', () async {
+      // arrange
+      final userProfile = testUserProfile;
+      // act
+      final userAvatarUrl = NetworkConfig.userAvatar(userProfile);
+
+      // assert
+      expect(
+        userAvatarUrl,
+        equals('$baseStaticUrl/${userProfile.profile.avatar}'),
+      );
+    });
+
+    test(
+        'should return null '
+        'when the user profile is null', () async {
+      // act
+      final userAvatarUrl = NetworkConfig.userAvatar(null);
+
+      // assert
+      expect(
+        userAvatarUrl,
+        equals(null),
+      );
+    });
+  });
+
+  group('[crowdActionBanner]', () {
+    test(
+        'should return crowdaction banner url '
+        'when the crowdaction is not null', () async {
+      // arrange
+      final crowdAction = testCrowdAction;
+
+      // act
+      final crowdActionBannerUrl = NetworkConfig.crowdActionBanner(crowdAction);
+
+      // assert
+      expect(
+        crowdActionBannerUrl,
+        equals('$baseStaticUrl/${crowdAction.images.banner}'),
+      );
+    });
+
+    test(
+        'should return null inclusive crowdaction banner url '
+        'when the crowdaction is null', () async {
+      // act
+      final crowdActionBannerUrl = NetworkConfig.crowdActionBanner(null);
+
+      // assert
+      // TODO(isaac): Could this be buggy
+      expect(
+        crowdActionBannerUrl,
+        equals('$baseStaticUrl/null'),
+      );
+    });
+  });
+
+  group('[crowdActionCard]', () {
+    test(
+        'should return crowdaction card url '
+        'when the crowdaction is not null', () async {
+      // arrange
+      final crowdAction = testCrowdAction;
+
+      // act
+      final crowdActionCardUrl = NetworkConfig.crowdActionCard(crowdAction);
+
+      // assert
+      expect(
+        crowdActionCardUrl,
+        equals('$baseStaticUrl/${crowdAction.images.card}'),
+      );
+    });
+
+    test(
+        'should return null inclusive crowdaction card url '
+        'when the crowdaction is null', () async {
+      // act
+      final crowdActionCardUrl = NetworkConfig.crowdActionCard(null);
+
+      // assert
+      // TODO(isaac): Could this be buggy
+      expect(
+        crowdActionCardUrl,
+        equals('$baseStaticUrl/null'),
+      );
+    });
+  });
+
+  group('[participationAvatar]', () {
+    test(
+        'should return participation avatar url '
+        'when the participation is not null', () async {
+      // arrange
+      final participation = testParticipation;
+
+      // act
+      final participationAvatarUrl =
+          NetworkConfig.participationAvatar(participation);
+
+      // assert
+      expect(
+        participationAvatarUrl,
+        equals('$baseStaticUrl/${participation.avatar}'),
+      );
+    });
+
+    test(
+        'should return null inclusive participation avatar url '
+        'when the participation is null', () async {
+      // act
+      final participationAvatarUrl = NetworkConfig.participationAvatar(null);
+
+      // assert
+      // TODO(isaac): Could this be buggy
+      expect(
+        participationAvatarUrl,
+        equals('$baseStaticUrl/null'),
+      );
+    });
+  });
+}

--- a/test/core/config/network.config_test.dart
+++ b/test/core/config/network.config_test.dart
@@ -1,4 +1,3 @@
-import 'package:collaction_app/core/core.dart';
 import 'package:collaction_app/domain/crowdaction/crowdaction.dart';
 import 'package:collaction_app/domain/participation/participation.dart';
 import 'package:collaction_app/domain/profile/user_profile.dart';
@@ -43,7 +42,7 @@ void main() {
       const UserProfile? userProfile = null;
 
       // act
-      final userAvatarUrl = userProfile.avatarUrl;
+      final userAvatarUrl = userProfile?.avatarUrl;
 
       // assert
       expect(
@@ -71,19 +70,18 @@ void main() {
     });
 
     test(
-        'should return null inclusive crowdaction banner url '
+        'should return null crowdaction banner url '
         'when the crowdaction is null', () async {
       // arrange
       const CrowdAction? crowdAction = null;
 
       // act
-      final crowdActionBannerUrl = crowdAction.bannerUrl;
+      final crowdActionBannerUrl = crowdAction?.bannerUrl;
 
       // assert
-      // TODO(isaac): Could this be buggy
       expect(
         crowdActionBannerUrl,
-        equals('$baseStaticUrl/null'),
+        equals(null),
       );
     });
   });
@@ -106,19 +104,18 @@ void main() {
     });
 
     test(
-        'should return null inclusive crowdaction card url '
+        'should return null crowdaction card url '
         'when the crowdaction is null', () async {
       // arrange
       const CrowdAction? crowdAction = null;
 
       // act
-      final crowdActionCardUrl = crowdAction.cardUrl;
+      final crowdActionCardUrl = crowdAction?.cardUrl;
 
       // assert
-      // TODO(isaac): Could this be buggy
       expect(
         crowdActionCardUrl,
-        equals('$baseStaticUrl/null'),
+        equals(null),
       );
     });
   });
@@ -141,19 +138,18 @@ void main() {
     });
 
     test(
-        'should return null inclusive participation avatar url '
+        'should return null participation avatar url '
         'when the participation is null', () async {
       // arrange
       const Participation? participation = null;
 
       // act
-      final participationAvatarUrl = participation.avatarUrl;
+      final participationAvatarUrl = participation?.avatarUrl;
 
       // assert
-      // TODO(isaac): Could this be buggy
       expect(
         participationAvatarUrl,
-        equals('$baseStaticUrl/null'),
+        equals(null),
       );
     });
   });

--- a/test/core/config/network.config_test.dart
+++ b/test/core/config/network.config_test.dart
@@ -1,4 +1,7 @@
 import 'package:collaction_app/core/core.dart';
+import 'package:collaction_app/domain/crowdaction/crowdaction.dart';
+import 'package:collaction_app/domain/participation/participation.dart';
+import 'package:collaction_app/domain/profile/user_profile.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -24,7 +27,7 @@ void main() {
       // arrange
       final userProfile = testUserProfile;
       // act
-      final userAvatarUrl = NetworkConfig.userAvatar(userProfile);
+      final userAvatarUrl = userProfile.avatarUrl;
 
       // assert
       expect(
@@ -36,8 +39,11 @@ void main() {
     test(
         'should return null '
         'when the user profile is null', () async {
+      // arrange
+      const UserProfile? userProfile = null;
+
       // act
-      final userAvatarUrl = NetworkConfig.userAvatar(null);
+      final userAvatarUrl = userProfile.avatarUrl;
 
       // assert
       expect(
@@ -55,7 +61,7 @@ void main() {
       final crowdAction = testCrowdAction;
 
       // act
-      final crowdActionBannerUrl = NetworkConfig.crowdActionBanner(crowdAction);
+      final crowdActionBannerUrl = crowdAction.bannerUrl;
 
       // assert
       expect(
@@ -67,8 +73,11 @@ void main() {
     test(
         'should return null inclusive crowdaction banner url '
         'when the crowdaction is null', () async {
+      // arrange
+      const CrowdAction? crowdAction = null;
+
       // act
-      final crowdActionBannerUrl = NetworkConfig.crowdActionBanner(null);
+      final crowdActionBannerUrl = crowdAction.bannerUrl;
 
       // assert
       // TODO(isaac): Could this be buggy
@@ -87,7 +96,7 @@ void main() {
       final crowdAction = testCrowdAction;
 
       // act
-      final crowdActionCardUrl = NetworkConfig.crowdActionCard(crowdAction);
+      final crowdActionCardUrl = crowdAction.cardUrl;
 
       // assert
       expect(
@@ -99,8 +108,11 @@ void main() {
     test(
         'should return null inclusive crowdaction card url '
         'when the crowdaction is null', () async {
+      // arrange
+      const CrowdAction? crowdAction = null;
+
       // act
-      final crowdActionCardUrl = NetworkConfig.crowdActionCard(null);
+      final crowdActionCardUrl = crowdAction.cardUrl;
 
       // assert
       // TODO(isaac): Could this be buggy
@@ -119,8 +131,7 @@ void main() {
       final participation = testParticipation;
 
       // act
-      final participationAvatarUrl =
-          NetworkConfig.participationAvatar(participation);
+      final participationAvatarUrl = participation.avatarUrl;
 
       // assert
       expect(
@@ -132,8 +143,11 @@ void main() {
     test(
         'should return null inclusive participation avatar url '
         'when the participation is null', () async {
+      // arrange
+      const Participation? participation = null;
+
       // act
-      final participationAvatarUrl = NetworkConfig.participationAvatar(null);
+      final participationAvatarUrl = participation.avatarUrl;
 
       // assert
       // TODO(isaac): Could this be buggy

--- a/test/utils/crowdaction.fixtures.dart
+++ b/test/utils/crowdaction.fixtures.dart
@@ -1,0 +1,17 @@
+import 'package:collaction_app/domain/crowdaction/crowdaction.dart';
+
+/// Reusable crowdaction fixtures
+final testCrowdAction = CrowdAction(
+  id: 'id',
+  type: 'type',
+  title: 'title',
+  description: 'description',
+  category: 'category',
+  location: const Location(code: 'code', name: 'name'),
+  commitmentOptions: [],
+  images: const Images(banner: 'banner.png', card: 'card.png'),
+  participantCount: 1,
+  status: Status.started,
+  joinStatus: JoinStatus.open,
+  endAt: DateTime.now(),
+);

--- a/test/utils/participation.fixtures.dart
+++ b/test/utils/participation.fixtures.dart
@@ -1,0 +1,16 @@
+import 'package:collaction_app/domain/participation/participation.dart';
+
+import 'crowdaction.fixtures.dart';
+import 'user.fixtures.dart';
+
+/// Reusable participation fixtures
+final testParticipation = Participation(
+  id: 'id',
+  crowdActionId: testCrowdAction.id,
+  fullName: testProfile.fullName,
+  avatar: testProfile.avatar,
+  userId: testUser.id,
+  commitmentOptions: [],
+  joinDate: DateTime.now(),
+  dailyCheckIns: 2,
+);

--- a/test/utils/user.fixtures.dart
+++ b/test/utils/user.fixtures.dart
@@ -1,0 +1,19 @@
+import 'package:collaction_app/domain/profile/profile.dart';
+import 'package:collaction_app/domain/profile/user_profile.dart';
+import 'package:collaction_app/domain/user/user.dart';
+
+/// Reusable user objects
+Future<String?> getUserIdToken([bool]) async {
+  return 'tokenId';
+}
+
+const testUser = User(id: 'id', getIdToken: getUserIdToken);
+
+final testProfile = Profile(
+  userId: testUser.id,
+  firstName: 'John',
+  lastName: 'Doe',
+  avatar: 'profiles/${testUser.id}.png',
+);
+
+final testUserProfile = UserProfile(user: testUser, profile: testProfile);

--- a/test/utils/user.fixtures.dart
+++ b/test/utils/user.fixtures.dart
@@ -3,11 +3,12 @@ import 'package:collaction_app/domain/profile/user_profile.dart';
 import 'package:collaction_app/domain/user/user.dart';
 
 /// Reusable user objects
-Future<String?> getUserIdToken([bool]) async {
+// ignore: avoid_types_as_parameter_names
+Future<String?> _getUserIdToken([bool]) async {
   return 'tokenId';
 }
 
-const testUser = User(id: 'id', getIdToken: getUserIdToken);
+const testUser = User(id: 'id', getIdToken: _getUserIdToken);
 
 final testProfile = Profile(
   userId: testUser.id,


### PR DESCRIPTION
The AuthBloc & ProfileBloc were being recreated (Since they are not singletons) whenever the auth screen was accessed, yet we already had them created in the app screen.

This was causing the profile screen to have a different ProfileBloc from the AuthScreen hence either the profile image wasn't updated when you signed in from a crowdaction or attempted to logout.

Closes #262 


https://user-images.githubusercontent.com/15793624/197702145-958bfc24-6558-46e1-b30b-65624c41c260.mp4

