### PR TITLE
feat(comment): Create comment action widgets

### DIFF
--- a/lib/presentation/crowdaction/crowdaction_comments/widgets/comment_delete_button.dart
+++ b/lib/presentation/crowdaction/crowdaction_comments/widgets/comment_delete_button.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
-
-///import '../../../core/collaction_icons.dart';
+import 'package:ionicons/ionicons.dart';
 
 class CommentDeleteButton extends StatelessWidget {
   final Function()? onTap;
@@ -13,8 +12,7 @@ class CommentDeleteButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return IconButton(
-      /// TODO: replace icons with variants from CollactionIcons
-      icon: const Icon(Icons.delete),
+      icon: const Icon(Ionicons.trash_outline),
       onPressed: onTap,
       iconSize: 14,
       splashRadius: 14,

--- a/lib/presentation/crowdaction/crowdaction_comments/widgets/comment_delete_button.dart
+++ b/lib/presentation/crowdaction/crowdaction_comments/widgets/comment_delete_button.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 
-import '../../../core/collaction_icons.dart';
+///import '../../../core/collaction_icons.dart';
 
 class CommentDeleteButton extends StatelessWidget {
   final Function()? onTap;

--- a/lib/presentation/crowdaction/crowdaction_comments/widgets/comment_delete_button.dart
+++ b/lib/presentation/crowdaction/crowdaction_comments/widgets/comment_delete_button.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+
+import '../../../core/collaction_icons.dart';
+
+class CommentDeleteButton extends StatelessWidget {
+  final Function()? onTap;
+
+  const CommentDeleteButton({
+    super.key,
+    this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return IconButton(
+      /// TODO: replace icons with variants from CollactionIcons
+      icon: const Icon(Icons.delete),
+      onPressed: onTap,
+      iconSize: 14,
+      splashRadius: 14,
+    );
+  }
+}

--- a/lib/presentation/crowdaction/crowdaction_comments/widgets/comment_flag_button.dart
+++ b/lib/presentation/crowdaction/crowdaction_comments/widgets/comment_flag_button.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
-
-///import '../../../core/collaction_icons.dart';
+import 'package:ionicons/ionicons.dart';
 
 class CommentFlagButton extends StatelessWidget {
   final bool flagged;
@@ -16,8 +15,9 @@ class CommentFlagButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return IconButton(
-      /// TODO: replace icons with variants from CollactionIcons
-      icon: flagged ? const Icon(Icons.flag) : const Icon(Icons.flag_outlined),
+      icon: flagged
+          ? const Icon(Ionicons.flag)
+          : const Icon(Ionicons.flag_outline),
       onPressed: onTap,
       iconSize: 14,
       splashRadius: 14,

--- a/lib/presentation/crowdaction/crowdaction_comments/widgets/comment_flag_button.dart
+++ b/lib/presentation/crowdaction/crowdaction_comments/widgets/comment_flag_button.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+
+import '../../../core/collaction_icons.dart';
+
+class CommentFlagButton extends StatelessWidget {
+  final bool flagged;
+
+  final Function()? onTap;
+
+  const CommentFlagButton({
+    super.key,
+    required this.flagged,
+    this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return IconButton(
+      /// TODO: replace icons with variants from CollactionIcons
+      icon: flagged ? const Icon(Icons.flag) : const Icon(Icons.flag_outlined),
+      onPressed: onTap,
+      iconSize: 14,
+      splashRadius: 14,
+    );
+  }
+}

--- a/lib/presentation/crowdaction/crowdaction_comments/widgets/comment_flag_button.dart
+++ b/lib/presentation/crowdaction/crowdaction_comments/widgets/comment_flag_button.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 
-import '../../../core/collaction_icons.dart';
+///import '../../../core/collaction_icons.dart';
 
 class CommentFlagButton extends StatelessWidget {
   final bool flagged;

--- a/lib/presentation/crowdaction/crowdaction_comments/widgets/comment_like_button.dart
+++ b/lib/presentation/crowdaction/crowdaction_comments/widgets/comment_like_button.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
-
-///import '../../../core/collaction_icons.dart';
+import 'package:ionicons/ionicons.dart';
 
 class CommentLikeButton extends StatelessWidget {
   final bool likedByMe;
@@ -15,10 +14,9 @@ class CommentLikeButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return IconButton(
-      /// TODO: replace icons with variants from CollactionIcons
       icon: likedByMe
-          ? const Icon(Icons.favorite)
-          : const Icon(Icons.favorite_border),
+          ? const Icon(Ionicons.heart)
+          : const Icon(Ionicons.heart_outline),
       onPressed: onTap,
       iconSize: 14,
       splashRadius: 14,

--- a/lib/presentation/crowdaction/crowdaction_comments/widgets/comment_like_button.dart
+++ b/lib/presentation/crowdaction/crowdaction_comments/widgets/comment_like_button.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 
-import '../../../core/collaction_icons.dart';
+///import '../../../core/collaction_icons.dart';
 
 class CommentLikeButton extends StatelessWidget {
   final bool likedByMe;

--- a/lib/presentation/crowdaction/crowdaction_comments/widgets/comment_like_button.dart
+++ b/lib/presentation/crowdaction/crowdaction_comments/widgets/comment_like_button.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/material.dart';
 
-class CrowdActionCommentLikeButton extends StatelessWidget {
+import '../../../core/collaction_icons.dart';
+
+class CommentLikeButton extends StatelessWidget {
   final bool likedByMe;
   final Function()? onTap;
 
-  const CrowdActionCommentLikeButton({
+  const CommentLikeButton({
     super.key,
     required this.likedByMe,
     this.onTap,
@@ -13,15 +15,14 @@ class CrowdActionCommentLikeButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return IconButton(
+      /// TODO: replace icons with variants from CollactionIcons
       icon: likedByMe
           ? const Icon(Icons.favorite)
           : const Icon(Icons.favorite_border),
       onPressed: onTap,
       iconSize: 14,
       splashRadius: 14,
-      color: likedByMe ? const Color(0xFFDD3333) : const Color(0xFF666666),
-      splashColor:
-          likedByMe ? const Color(0x33666666) : const Color(0x33DD3333),
+      color: likedByMe ? Colors.redAccent : null,
     );
   }
 }

--- a/lib/presentation/crowdaction/crowdaction_comments/widgets/crowdaction_comment_like_button.dart
+++ b/lib/presentation/crowdaction/crowdaction_comments/widgets/crowdaction_comment_like_button.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+
+class CrowdActionCommentLikeButton extends StatelessWidget {
+  final bool likedByMe;
+  final Function()? onTap;
+
+  const CrowdActionCommentLikeButton({
+    super.key,
+    required this.likedByMe,
+    this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return IconButton(
+      icon: likedByMe
+          ? const Icon(Icons.favorite)
+          : const Icon(Icons.favorite_border),
+      onPressed: onTap,
+      iconSize: 14,
+      splashRadius: 14,
+      color: likedByMe ? const Color(0xFFDD3333) : const Color(0xFF666666),
+      splashColor:
+          likedByMe ? const Color(0x33666666) : const Color(0x33DD3333),
+    );
+  }
+}

--- a/lib/presentation/crowdaction/crowdaction_comments/widgets/flag_comment.dart
+++ b/lib/presentation/crowdaction/crowdaction_comments/widgets/flag_comment.dart
@@ -1,0 +1,242 @@
+import 'package:auto_route/auto_route.dart';
+import 'package:flutter/material.dart';
+
+import '../../../shared_widgets/pill_button.dart';
+import '../../../shared_widgets/selectable_chip.dart';
+import '../../../themes/constants.dart';
+
+class FlagComment extends StatelessWidget {
+  final bool flagged;
+
+  const FlagComment({
+    super.key,
+    this.flagged = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    /// to be replaced with a BlocBuilder to swap between dialog and success
+    if (!flagged) {
+      return FlagDialog(
+        /// need clarification - will these be defined/accessible in the API? do we need a flag obj?
+        flags: ["Spam", "Illegal", "Hateful", "Sexual", "Other"],
+      );
+    }
+    return FlagSuccess();
+  }
+}
+
+class FlagDialog extends StatefulWidget {
+  final bool isLoading;
+  final List<String> flags;
+
+  const FlagDialog({
+    super.key,
+    this.isLoading = false,
+    this.flags = const [],
+  });
+
+  @override
+  State<FlagDialog> createState() => FlagDialogState();
+}
+
+class FlagDialogState extends State<FlagDialog> {
+  late List<String> _flags;
+  late List<bool> _selectedFlags;
+  late bool _isLoading;
+
+  void updateFlag(int index) {
+    setState(() {
+      _selectedFlags[index] = !_selectedFlags[index];
+    });
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _isLoading = widget.isLoading;
+    _flags = widget.flags;
+    _selectedFlags = List.filled(_flags.length, false);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 20),
+      child: Column(mainAxisSize: MainAxisSize.min, children: [
+        const SizedBox(
+          height: 15,
+        ),
+        Container(
+          width: 60.0,
+          height: 5.0,
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(10.0),
+            color: kSecondaryTransparent,
+          ),
+        ),
+        const SizedBox(
+          height: 20,
+        ),
+        Text(
+          "Report comment",
+          textAlign: TextAlign.center,
+          style: Theme.of(context)
+              .textTheme
+              .subtitle1
+              ?.copyWith(fontWeight: FontWeight.bold),
+        ),
+        const SizedBox(
+          height: 30,
+        ),
+        Container(
+          constraints: const BoxConstraints(maxHeight: 300),
+          child: ListView(
+            shrinkWrap: true,
+            children: [
+              Container(
+                constraints: const BoxConstraints(maxHeight: 80),
+                child: Text(
+                  "Modal description. Nam quis nulla. Integer malesuada. In in enim a arcu imperdiet malesuada. Sed vel lectus. Donec odio uma, tempus molestie, porttitor ut, iaculis quis.",
+                  overflow: TextOverflow.fade,
+                  style: Theme.of(context).textTheme.caption?.copyWith(
+                        color: kPrimaryColor400,
+                      ),
+                  textAlign: TextAlign.center,
+                ),
+              ),
+              const SizedBox(height: 20),
+              Container(
+                margin: const EdgeInsets.symmetric(horizontal: 50),
+                child: Wrap(
+                    alignment: WrapAlignment.center,
+                    direction: Axis.horizontal,
+                    children: List.generate(_flags.length, (index) {
+                      return Container(
+                        margin: const EdgeInsets.symmetric(horizontal: 5),
+                        child: SelectableChip(
+                          onTap: () => setState(() {
+                            _selectedFlags[index] = !_selectedFlags[index];
+                          }),
+                          selected: _selectedFlags[index],
+                          text: _flags[index],
+                        ),
+                      );
+                    })),
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(
+          height: 20,
+        ),
+        PillButton(
+          text: "Report Comment",
+          isLoading: _isLoading,
+          isEnabled: _selectedFlags.contains(true),
+          margin: EdgeInsets.zero,
+          onTap: () {
+            /// do something with _selectedFlags - CommentEvent.flagComment?
+          },
+        ),
+        const SizedBox(height: 20),
+        SizedBox(
+          width: double.infinity,
+          height: 52,
+          child: TextButton(
+            onPressed: () => context.router.pop(),
+            child: const Text("Cancel"),
+          ),
+        ),
+        const SizedBox(
+          height: 15,
+        ),
+      ]),
+    );
+  }
+}
+
+class FlagSuccess extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 20),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const SizedBox(
+            height: 15,
+          ),
+          Container(
+            width: 60.0,
+            height: 5.0,
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(10.0),
+              color: kSecondaryTransparent,
+            ),
+          ),
+          const SizedBox(
+            height: 20,
+          ),
+          Text(
+            "Report comment",
+            textAlign: TextAlign.center,
+            style: Theme.of(context)
+                .textTheme
+                .subtitle1
+                ?.copyWith(fontWeight: FontWeight.bold),
+          ),
+          const SizedBox(
+            height: 28,
+          ),
+          Text(
+            "Successfully reported",
+            textAlign: TextAlign.center,
+            style: Theme.of(context).textTheme.subtitle1?.copyWith(
+                  fontWeight: FontWeight.bold,
+                  fontSize: 28,
+                ),
+          ),
+          const SizedBox(
+            height: 20,
+          ),
+          Container(
+            child: Text(
+              "Thank you for letting us know. We will look into it and dlete the comment if necessary.",
+              style: Theme.of(context).textTheme.caption?.copyWith(
+                    color: kPrimaryColor400,
+                  ),
+              textAlign: TextAlign.center,
+            ),
+            padding: EdgeInsets.symmetric(horizontal: 50),
+            alignment: Alignment.center,
+          ),
+          const SizedBox(
+            height: 20,
+          ),
+          PillButton(
+            text: "Got it",
+            onTap: () {
+              context.router.pop();
+            },
+            margin: EdgeInsets.zero,
+          ),
+          const SizedBox(height: 20),
+          SizedBox(
+            width: double.infinity,
+            height: 52,
+            child: TextButton(
+              onPressed: () {
+                /// undo flagging
+              },
+              child: const Text("Undo"),
+            ),
+          ),
+          const SizedBox(
+            height: 15,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/presentation/crowdaction/crowdaction_comments/widgets/flag_comment.dart
+++ b/lib/presentation/crowdaction/crowdaction_comments/widgets/flag_comment.dart
@@ -109,20 +109,21 @@ class FlagDialogState extends State<FlagDialog> {
               Container(
                 margin: const EdgeInsets.symmetric(horizontal: 50),
                 child: Wrap(
-                    alignment: WrapAlignment.center,
-                    direction: Axis.horizontal,
-                    children: List.generate(_flags.length, (index) {
-                      return Container(
-                        margin: const EdgeInsets.symmetric(horizontal: 5),
-                        child: SelectableChip(
-                          onTap: () => setState(() {
-                            _selectedFlags[index] = !_selectedFlags[index];
-                          }),
-                          selected: _selectedFlags[index],
-                          text: _flags[index],
-                        ),
-                      );
-                    })),
+                  alignment: WrapAlignment.center,
+                  direction: Axis.horizontal,
+                  children: List.generate(_flags.length, (index) {
+                    return Container(
+                      margin: const EdgeInsets.symmetric(horizontal: 5),
+                      child: SelectableChip(
+                        onTap: () => setState(() {
+                          _selectedFlags[index] = !_selectedFlags[index];
+                        }),
+                        selected: _selectedFlags[index],
+                        text: _flags[index],
+                      ),
+                    );
+                  }),
+                ),
               ),
             ],
           ),

--- a/lib/presentation/demo/components_demo/components_demo_screen.dart
+++ b/lib/presentation/demo/components_demo/components_demo_screen.dart
@@ -10,6 +10,7 @@ import '../../shared_widgets/custom_fab.dart';
 import '../../shared_widgets/pill_button.dart';
 import '../../shared_widgets/rectangle_button.dart';
 import '../../shared_widgets/secondary_chip.dart';
+import '../../crowdaction/crowdaction_comments/widgets/crowdaction_comment_like_button.dart';
 
 class ComponentsDemoPage extends StatefulWidget {
   const ComponentsDemoPage({super.key});
@@ -19,6 +20,13 @@ class ComponentsDemoPage extends StatefulWidget {
 }
 
 class ComponentsDemoPageState extends State<ComponentsDemoPage> {
+  bool likedByMe = true;
+  void likeCallback() {
+    setState(() {
+      likedByMe = !likedByMe;
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -252,6 +260,16 @@ class ComponentsDemoPageState extends State<ComponentsDemoPage> {
                   const CustomFAB(
                     heroTag: 'fab4',
                     child: Icon(Icons.add),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 24.0),
+              Wrap(
+                spacing: 12.0,
+                children: [
+                  CrowdActionCommentLikeButton(
+                    likedByMe: likedByMe,
+                    onTap: likeCallback,
                   ),
                 ],
               ),

--- a/lib/presentation/demo/components_demo/components_demo_screen.dart
+++ b/lib/presentation/demo/components_demo/components_demo_screen.dart
@@ -1,4 +1,6 @@
+import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
+import 'package:http/http.dart';
 
 import '../../../domain/crowdaction/crowdaction.dart';
 import '../../core/collaction_icons.dart';
@@ -10,7 +12,11 @@ import '../../shared_widgets/custom_fab.dart';
 import '../../shared_widgets/pill_button.dart';
 import '../../shared_widgets/rectangle_button.dart';
 import '../../shared_widgets/secondary_chip.dart';
-import '../../crowdaction/crowdaction_comments/widgets/crowdaction_comment_like_button.dart';
+import '../../crowdaction/crowdaction_comments/widgets/comment_delete_button.dart';
+import '../../crowdaction/crowdaction_comments/widgets/comment_like_button.dart';
+import '../../crowdaction/crowdaction_comments/widgets/comment_flag_button.dart';
+import '../../crowdaction/crowdaction_comments/widgets/flag_comment.dart';
+import '../../themes/constants.dart';
 
 class ComponentsDemoPage extends StatefulWidget {
   const ComponentsDemoPage({super.key});
@@ -20,10 +26,18 @@ class ComponentsDemoPage extends StatefulWidget {
 }
 
 class ComponentsDemoPageState extends State<ComponentsDemoPage> {
-  bool likedByMe = true;
+  bool likedByMe = false;
   void likeCallback() {
     setState(() {
       likedByMe = !likedByMe;
+    });
+  }
+
+  bool flagged = false;
+  void flagCallback(List<bool>? flags) {
+    setState(() {
+      flagged = true;
+      debugPrint(flags?.toString());
     });
   }
 
@@ -264,12 +278,23 @@ class ComponentsDemoPageState extends State<ComponentsDemoPage> {
                 ],
               ),
               const SizedBox(height: 24.0),
+
+              /// TEMP: delete once #304 is approved
               Wrap(
                 spacing: 12.0,
                 children: [
-                  CrowdActionCommentLikeButton(
+                  CommentLikeButton(
                     likedByMe: likedByMe,
                     onTap: likeCallback,
+                  ),
+                  CommentFlagButton(
+                    flagged: flagged,
+                    onTap: () => {
+                      if (!flagged) _flagModal(context) else flagged = !flagged
+                    },
+                  ),
+                  CommentDeleteButton(
+                    onTap: () => _deleteModal(context),
                   ),
                 ],
               ),
@@ -278,6 +303,85 @@ class ComponentsDemoPageState extends State<ComponentsDemoPage> {
           ),
         ),
       ),
+    );
+  }
+
+  /// TEMP: move modals to CrowdActionCommentPage once #304 is approved
+  void _deleteModal(BuildContext context) {
+    showModalBottomSheet(
+        context: context,
+        shape: const RoundedRectangleBorder(
+          borderRadius: BorderRadius.only(
+            topLeft: Radius.circular(20),
+            topRight: Radius.circular(20),
+          ),
+        ),
+        builder: (context) {
+          return Container(
+            padding: const EdgeInsets.symmetric(horizontal: 20),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                const SizedBox(height: 15),
+                Container(
+                  width: 60.0,
+                  height: 5.0,
+                  decoration: BoxDecoration(
+                    borderRadius: BorderRadius.circular(10.0),
+                    color: kSecondaryTransparent,
+                  ),
+                ),
+                const SizedBox(
+                  height: 20,
+                ),
+                Text(
+                  "Delete comment",
+                  style: Theme.of(context)
+                      .textTheme
+                      .subtitle1
+                      ?.copyWith(fontWeight: FontWeight.bold),
+                ),
+                const SizedBox(height: 30),
+                PillButton(
+                  text: "Delete my comment",
+                  onTap: () => {},
+                  margin: EdgeInsets.zero,
+                ),
+                const SizedBox(height: 20),
+                SizedBox(
+                  width: double.infinity,
+                  height: 52,
+                  child: TextButton(
+                    onPressed: () {
+                      context.router.pop();
+                    },
+                    child: const Text("Cancel"),
+                  ),
+                ),
+                const SizedBox(
+                  height: 15,
+                ),
+              ],
+            ),
+          );
+        });
+  }
+
+  void _flagModal(BuildContext context) {
+    showModalBottomSheet(
+      isScrollControlled: true,
+      context: context,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.only(
+          topLeft: Radius.circular(20),
+          topRight: Radius.circular(20),
+        ),
+      ),
+      builder: (context) {
+        return FlagComment(
+          flagged: false,
+        );
+      },
     );
   }
 }

--- a/lib/presentation/demo/components_demo/components_demo_screen.dart
+++ b/lib/presentation/demo/components_demo/components_demo_screen.dart
@@ -1,6 +1,5 @@
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
-import 'package:http/http.dart';
 
 import '../../../domain/crowdaction/crowdaction.dart';
 import '../../core/collaction_icons.dart';

--- a/lib/presentation/shared_widgets/selectable_chip.dart
+++ b/lib/presentation/shared_widgets/selectable_chip.dart
@@ -17,38 +17,38 @@ class SelectableChip extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return AnimatedSwitcher(
-        duration: Duration(
-          milliseconds: 200,
-        ),
-        child: SizedBox(
-          key: ValueKey<bool>(selected),
-          child: TextButton(
-            onPressed: onTap,
-            style: ButtonStyle(
-              padding: MaterialStateProperty.all<EdgeInsets?>(
-                const EdgeInsets.symmetric(horizontal: 10.0),
-              ),
-              shape: MaterialStateProperty.all<OutlinedBorder>(
-                StadiumBorder(
-                    side: BorderSide(
-                        color:
-                            selected ? kPrimaryColor400 : kAlmostTransparent)),
-              ),
-              overlayColor: MaterialStateColor.resolveWith(
-                (states) => kSecondaryColor.withOpacity(0.1),
-              ),
-              backgroundColor: MaterialStateProperty.all(
-                  selected ? kPrimaryColor400 : kSecondaryColor),
+      duration: Duration(
+        milliseconds: 200,
+      ),
+      child: SizedBox(
+        key: ValueKey<bool>(selected),
+        child: TextButton(
+          onPressed: onTap,
+          style: ButtonStyle(
+            padding: MaterialStateProperty.all<EdgeInsets?>(
+              const EdgeInsets.symmetric(horizontal: 10.0),
             ),
-            child: Text(
-              text,
-              style: Theme.of(context).textTheme.caption?.copyWith(
-                    fontSize: 11,
-                    color: selected ? kSecondaryColor : kPrimaryColor400,
-                    fontWeight: FontWeight.w700,
-                  ),
+            shape: MaterialStateProperty.all<OutlinedBorder>(
+              StadiumBorder(
+                  side: BorderSide(
+                      color: selected ? kPrimaryColor400 : kAlmostTransparent)),
             ),
+            overlayColor: MaterialStateColor.resolveWith(
+              (states) => kSecondaryColor.withOpacity(0.1),
+            ),
+            backgroundColor: MaterialStateProperty.all(
+                selected ? kPrimaryColor400 : kSecondaryColor),
           ),
-        ));
+          child: Text(
+            text,
+            style: Theme.of(context).textTheme.caption?.copyWith(
+                  fontSize: 11,
+                  color: selected ? kSecondaryColor : kPrimaryColor400,
+                  fontWeight: FontWeight.w700,
+                ),
+          ),
+        ),
+      ),
+    );
   }
 }

--- a/lib/presentation/shared_widgets/selectable_chip.dart
+++ b/lib/presentation/shared_widgets/selectable_chip.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+
+import '../themes/constants.dart';
+
+class SelectableChip extends StatelessWidget {
+  final String text;
+  final bool selected;
+  final VoidCallback? onTap;
+
+  const SelectableChip({
+    super.key,
+    required this.text,
+    this.selected = false,
+    this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedSwitcher(
+        duration: Duration(
+          milliseconds: 200,
+        ),
+        child: SizedBox(
+          key: ValueKey<bool>(selected),
+          child: TextButton(
+            onPressed: onTap,
+            style: ButtonStyle(
+              padding: MaterialStateProperty.all<EdgeInsets?>(
+                const EdgeInsets.symmetric(horizontal: 10.0),
+              ),
+              shape: MaterialStateProperty.all<OutlinedBorder>(
+                StadiumBorder(
+                    side: BorderSide(
+                        color:
+                            selected ? kPrimaryColor400 : kAlmostTransparent)),
+              ),
+              overlayColor: MaterialStateColor.resolveWith(
+                (states) => kSecondaryColor.withOpacity(0.1),
+              ),
+              backgroundColor: MaterialStateProperty.all(
+                  selected ? kPrimaryColor400 : kSecondaryColor),
+            ),
+            child: Text(
+              text,
+              style: Theme.of(context).textTheme.caption?.copyWith(
+                    fontSize: 11,
+                    color: selected ? kSecondaryColor : kPrimaryColor400,
+                    fontWeight: FontWeight.w700,
+                  ),
+            ),
+          ),
+        ));
+  }
+}


### PR DESCRIPTION
Motivation: add widgets for comment like, flag and delete, and the appropriate popup dialogs.
Relates: #175 

Widget demos:
[commentwidgets.webm](https://user-images.githubusercontent.com/34312863/204622576-81102b5a-321c-4bed-9898-4899059792eb.webm)
The specific dialog for when a report is sent:
[flaggeddialog.webm](https://user-images.githubusercontent.com/34312863/204622733-cde5149d-2b13-4f64-a431-e85e86be1830.webm)
