### PR TITLE
fix showPasswordModal() RenderFlex_bottom_overflow

### DIFF
--- a/lib/presentation/home/widgets/password_modal.dart
+++ b/lib/presentation/home/widgets/password_modal.dart
@@ -185,6 +185,7 @@ Future<void> showPasswordModal(
   } else {
     showModalBottomSheet(
       context: context,
+      isScrollControlled: true,
       backgroundColor: Colors.transparent,
       constraints: const BoxConstraints(maxHeight: 350),
       builder: (context) => PasswordModal(crowdAction: crowdAction),


### PR DESCRIPTION
After setting the isScrollControlled parameter to true. The bottom render overflow error disappear. And ModalBottom sheet is now fully visible when keyboard is on screen.
<img width="926" alt="solution_isScrollControlled true" src="https://user-images.githubusercontent.com/39384008/209660800-73ca5e35-6291-4bd7-985d-48a524c82e58.png">
