### PR TITLE
fix: Exception on empty screen

### DIFF
--- a/lib/presentation/crowdaction/crowdaction_home/widgets/in_spotlight_header.dart
+++ b/lib/presentation/crowdaction/crowdaction_home/widgets/in_spotlight_header.dart
@@ -1,13 +1,11 @@
-import 'package:dots_indicator/dots_indicator.dart';
-import 'package:expandable_page_view/expandable_page_view.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:intl/intl.dart';
 
 import '../../../../application/crowdaction/spotlight/spotlight_bloc.dart';
 import '../../../shared_widgets/content_placeholder.dart';
-import '../../../shared_widgets/crowdaction_card.dart';
 import '../../../themes/constants.dart';
+import 'spotlight_crowdactions/spotlight_crowdactions.dart';
 
 class InSpotLightHeader extends StatefulWidget {
   const InSpotLightHeader({
@@ -19,18 +17,6 @@ class InSpotLightHeader extends StatefulWidget {
 }
 
 class _InSpotLightHeaderState extends State<InSpotLightHeader> {
-  final _pageController = PageController();
-  double _currentPage = 0.0;
-
-  @override
-  void initState() {
-    super.initState();
-
-    _pageController.addListener(
-      () => setState(() => _currentPage = _pageController.page!),
-    );
-  }
-
   @override
   Widget build(BuildContext context) {
     return BlocProvider.value(
@@ -64,11 +50,7 @@ class _InSpotLightHeaderState extends State<InSpotLightHeader> {
                   builder: (context, state) {
                     return state.maybeWhen(
                       fetchingCrowdSpotLightActions: () {
-                        return const Center(
-                          child: CircularProgressIndicator(
-                            color: kAccentColor,
-                          ),
-                        );
+                        return const SpotlightEmptyHeader();
                       },
                       spotLightCrowdActionsError: (_) {
                         return const ContentPlaceholder(
@@ -76,38 +58,7 @@ class _InSpotLightHeaderState extends State<InSpotLightHeader> {
                         );
                       },
                       spotLightCrowdActions: (pages) {
-                        return Column(
-                          children: [
-                            ExpandablePageView.builder(
-                              itemBuilder: (ctx, index) {
-                                final crowdAction = pages[index];
-                                return CrowdActionCard(
-                                  crowdAction: crowdAction,
-                                );
-                              },
-                              itemCount: pages.length,
-                              controller: _pageController,
-                            ),
-                            const SizedBox(height: 5),
-                            Row(
-                              children: [
-                                const Expanded(child: SizedBox()),
-                                DotsIndicator(
-                                  position: _currentPage,
-                                  dotsCount: pages.length,
-                                  decorator: const DotsDecorator(
-                                    activeColor: kAccentColor,
-                                    color: Color(0xFFCCCCCC),
-                                    size: Size(12.0, 12.0),
-                                    activeSize: Size(12.0, 12.0),
-                                    spacing: EdgeInsets.all(8.0),
-                                  ),
-                                ),
-                                const Expanded(child: SizedBox()),
-                              ],
-                            ),
-                          ],
-                        );
+                        return SpotlightCrowdActions(pages: pages);
                       },
                       orElse: () => const SizedBox(),
                     );

--- a/lib/presentation/crowdaction/crowdaction_home/widgets/spotlight_crowdactions/in_spotlight_header_empty.dart
+++ b/lib/presentation/crowdaction/crowdaction_home/widgets/spotlight_crowdactions/in_spotlight_header_empty.dart
@@ -1,0 +1,90 @@
+part of 'spotlight_crowdactions.dart';
+
+class SpotlightEmptyHeader extends StatelessWidget {
+  const SpotlightEmptyHeader({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Shimmer.fromColors(
+      baseColor: Colors.black.withOpacity(0.1),
+      highlightColor: Colors.white.withOpacity(0.2),
+      child: Container(
+        margin: const EdgeInsets.symmetric(horizontal: 20),
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.all(Radius.circular(20)),
+          border: Border.all(),
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Container(
+              height: 215,
+              decoration: BoxDecoration(
+                color: Colors.grey,
+                borderRadius: BorderRadius.only(
+                  topLeft: Radius.circular(20),
+                  topRight: Radius.circular(20),
+                ),
+              ),
+            ),
+            const SizedBox(height: 5.0),
+            Row(
+              children: [
+                const SizedBox(width: 15.0),
+                SecondaryChip(text: "Sample text"),
+                const SizedBox(width: 12),
+                SecondaryChip(text: "Sample text"),
+                const SizedBox(height: 5.0),
+              ],
+            ),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 15.0),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Container(
+                    height: 22,
+                    decoration: BoxDecoration(
+                      borderRadius: BorderRadius.all(Radius.circular(20)),
+                      color: Colors.black,
+                    ),
+                    width: 250,
+                  ),
+                  const SizedBox(height: 5.0),
+                  Container(
+                    height: 22,
+                    decoration: BoxDecoration(
+                      borderRadius: BorderRadius.all(Radius.circular(20)),
+                      color: Colors.black,
+                    ),
+                    width: 200,
+                  ),
+                  const SizedBox(height: 5.0),
+                  Container(
+                    height: 22,
+                    decoration: BoxDecoration(
+                      borderRadius: BorderRadius.all(Radius.circular(20)),
+                      color: Colors.black,
+                    ),
+                    width: 150,
+                  ),
+                ],
+              ),
+            ),
+            Container(
+              height: 50,
+              margin: EdgeInsets.fromLTRB(10, 15, 10, 15),
+              padding: EdgeInsets.only(top: 10),
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.all(Radius.circular(25)),
+                color: Colors.black,
+              ),
+              width: double.infinity,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/crowdaction/crowdaction_home/widgets/spotlight_crowdactions/spotlight_crowdactions.dart
+++ b/lib/presentation/crowdaction/crowdaction_home/widgets/spotlight_crowdactions/spotlight_crowdactions.dart
@@ -1,0 +1,76 @@
+import 'package:dots_indicator/dots_indicator.dart';
+import 'package:expandable_page_view/expandable_page_view.dart';
+import 'package:flutter/material.dart';
+import 'package:shimmer/shimmer.dart';
+
+import '../../../../../domain/crowdaction/crowdaction.dart';
+import '../../../../shared_widgets/crowdaction_card.dart';
+import '../../../../shared_widgets/secondary_chip.dart';
+import '../../../../themes/constants.dart';
+
+part 'in_spotlight_header_empty.dart';
+
+class SpotlightCrowdActions extends StatefulWidget {
+  final List<CrowdAction> pages;
+  const SpotlightCrowdActions({
+    super.key,
+    required this.pages,
+  });
+
+  @override
+  State<SpotlightCrowdActions> createState() => _SpotlightCrowdActionsState();
+}
+
+class _SpotlightCrowdActionsState extends State<SpotlightCrowdActions> {
+  final _pageController = PageController();
+  double _currentPage = 0.0;
+
+  @override
+  void initState() {
+    super.initState();
+
+    _pageController.addListener(
+      () => setState(() => _currentPage = _pageController.page!),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (widget.pages.isEmpty) {
+      return const SpotlightEmptyHeader();
+    }
+
+    return Column(
+      children: [
+        ExpandablePageView.builder(
+          itemBuilder: (ctx, index) {
+            final crowdAction = widget.pages[index];
+            return CrowdActionCard(
+              crowdAction: crowdAction,
+            );
+          },
+          itemCount: widget.pages.length,
+          controller: _pageController,
+        ),
+        const SizedBox(height: 5),
+        Row(
+          children: [
+            const Expanded(child: SizedBox()),
+            DotsIndicator(
+              position: _currentPage,
+              dotsCount: widget.pages.length,
+              decorator: const DotsDecorator(
+                activeColor: kAccentColor,
+                color: Color(0xFFCCCCCC),
+                size: Size(12.0, 12.0),
+                activeSize: Size(12.0, 12.0),
+                spacing: EdgeInsets.all(8.0),
+              ),
+            ),
+            const Expanded(child: SizedBox()),
+          ],
+        ),
+      ],
+    );
+  }
+}

--- a/lib/presentation/home/widgets/current_upcoming_layout.dart
+++ b/lib/presentation/home/widgets/current_upcoming_layout.dart
@@ -6,6 +6,7 @@ import '../../../application/crowdaction/spotlight/spotlight_bloc.dart';
 import '../../routes/app_routes.gr.dart';
 import '../../shared_widgets/content_placeholder.dart';
 import '../../shared_widgets/micro_crowdaction_card.dart';
+import '../../shared_widgets/micro_crowdaction_card_loading.dart';
 import '../../themes/constants.dart';
 
 class CurrentAndUpcomingLayout extends StatefulWidget {
@@ -67,26 +68,28 @@ class _CurrentAndUpcomingLayoutState extends State<CurrentAndUpcomingLayout> {
                     ),
                   ),
                   state.maybeMap(
-                    fetchingCrowdSpotLightActions: (_) => const Center(
-                      child: CircularProgressIndicator(
-                        color: kAccentColor,
-                      ),
-                    ),
-                    spotLightCrowdActions: (fetchedData) => Column(
-                      children: [
-                        ...fetchedData.crowdActions
-                            .map(
-                              (crowdAction) => Padding(
-                                padding: const EdgeInsets.symmetric(
-                                  vertical: 10,
-                                  horizontal: 10,
+                    fetchingCrowdSpotLightActions: (_) => _loading(),
+                    spotLightCrowdActions: (fetchedData) {
+                      if (fetchedData.crowdActions.isEmpty) {
+                        return _loading();
+                      }
+
+                      return Column(
+                        children: [
+                          ...fetchedData.crowdActions
+                              .map(
+                                (crowdAction) => Padding(
+                                  padding: const EdgeInsets.symmetric(
+                                    vertical: 10,
+                                    horizontal: 10,
+                                  ),
+                                  child: MicroCrowdActionCard(crowdAction),
                                 ),
-                                child: MicroCrowdActionCard(crowdAction),
-                              ),
-                            )
-                            .toList(),
-                      ],
-                    ),
+                              )
+                              .toList(),
+                        ],
+                      );
+                    },
                     spotLightCrowdActionsError: (failure) =>
                         const ContentPlaceholder(
                       textColor: Colors.black,
@@ -99,6 +102,27 @@ class _CurrentAndUpcomingLayoutState extends State<CurrentAndUpcomingLayout> {
           },
         ),
       ),
+    );
+  }
+
+  Widget _loading() {
+    return Column(
+      children: [
+        Padding(
+          padding: const EdgeInsets.symmetric(
+            vertical: 10,
+            horizontal: 10,
+          ),
+          child: MicroCrowdActionCardLoading(),
+        ),
+        Padding(
+          padding: const EdgeInsets.symmetric(
+            vertical: 10,
+            horizontal: 10,
+          ),
+          child: MicroCrowdActionCardLoading(),
+        ),
+      ],
     );
   }
 }

--- a/lib/presentation/shared_widgets/micro_crowdaction_card_loading.dart
+++ b/lib/presentation/shared_widgets/micro_crowdaction_card_loading.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+import 'package:shimmer/shimmer.dart';
+
+import 'accent_chip.dart';
+
+class MicroCrowdActionCardLoading extends StatelessWidget {
+  const MicroCrowdActionCardLoading({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Shimmer.fromColors(
+      baseColor: Colors.black.withOpacity(0.1),
+      highlightColor: Colors.white.withOpacity(0.2),
+      child: Container(
+        height: 148,
+        decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(15),
+            border: Border.all(color: Colors.black)),
+        child: Row(
+          children: [
+            Container(
+              decoration: BoxDecoration(
+                borderRadius: BorderRadius.circular(15),
+                color: Colors.black,
+              ),
+              margin: const EdgeInsets.only(left: 10),
+              height: 128,
+              width: 100,
+            ),
+            Expanded(
+              child: Padding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 10,
+                  vertical: 10,
+                ),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      children: [
+                        AccentChip(
+                          text: "Currently running",
+                        ),
+                        const SizedBox(width: 10),
+                        Container(
+                          width: 32,
+                          height: 32,
+                          decoration: BoxDecoration(
+                            shape: BoxShape.circle,
+                            color: Colors.black,
+                          ),
+                        ),
+                      ],
+                    ),
+                    Container(
+                      margin: const EdgeInsets.only(
+                        top: 10,
+                      ),
+                      decoration: BoxDecoration(
+                          color: Colors.black,
+                          borderRadius: BorderRadius.circular(24)),
+                      height: 17,
+                      width: 90,
+                    ),
+                    Container(
+                      margin: const EdgeInsets.only(
+                        top: 6,
+                        bottom: 2,
+                      ),
+                      decoration: BoxDecoration(
+                          color: Colors.black,
+                          borderRadius: BorderRadius.circular(24)),
+                      height: 12,
+                      width: 200,
+                    ),
+                    Container(
+                      margin: const EdgeInsets.only(
+                        top: 6,
+                      ),
+                      decoration: BoxDecoration(
+                          color: Colors.black,
+                          borderRadius: BorderRadius.circular(24)),
+                      height: 12,
+                      width: 200,
+                    ),
+                  ],
+                ),
+              ),
+            )
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/test/application/crowdaction/spotlight/spotlight_bloc.mocks.dart
+++ b/test/application/crowdaction/spotlight/spotlight_bloc.mocks.dart
@@ -1,0 +1,5 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:collaction_app/application/crowdaction/spotlight/spotlight_bloc.dart';
+
+class MockSpotlightBloc extends MockBloc<SpotlightEvent, SpotlightState>
+    implements SpotlightBloc {}

--- a/test/presentation/crowdaction/crowdaction_home/widgets/spotlight_crowdactions/spotlight_crowdactions_test.dart
+++ b/test/presentation/crowdaction/crowdaction_home/widgets/spotlight_crowdactions/spotlight_crowdactions_test.dart
@@ -1,0 +1,85 @@
+import 'package:collaction_app/application/crowdaction/crowdaction_details/crowdaction_details_bloc.dart';
+import 'package:collaction_app/application/participation/top_participants/top_participants_bloc.dart';
+import 'package:collaction_app/domain/crowdaction/crowdaction.dart';
+import 'package:collaction_app/presentation/crowdaction/crowdaction_home/widgets/spotlight_crowdactions/spotlight_crowdactions.dart';
+import 'package:dots_indicator/dots_indicator.dart';
+import 'package:expandable_page_view/expandable_page_view.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get_it/get_it.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../../../application/crowdaction/crowdaction_details/crowdaction_details_bloc.mocks.dart';
+import '../../../../../application/participation/top_participants/top_participants_bloc.mocks.dart';
+import '../../../../../test_utilities.dart';
+import '../../../../../utils/crowdactions.dart';
+
+void main() {
+  late TopParticipantsBloc topParticipantsBloc;
+  late CrowdActionDetailsBloc crowdActionDetailsBloc;
+
+  setUpAll(() {
+    dotenv.testLoad(fileInput: tDotEnv);
+
+    // Top Participants Bloc
+    topParticipantsBloc = MockTopParticipantsBloc();
+    when(() => topParticipantsBloc.state)
+        .thenAnswer((_) => TopParticipantsState.initial());
+    GetIt.instance.registerSingleton<TopParticipantsBloc>(topParticipantsBloc);
+
+    // Crowd action details bloc
+    crowdActionDetailsBloc = MockCrowdActionDetailsBloc();
+    when(() => crowdActionDetailsBloc.state)
+        .thenAnswer((_) => CrowdActionDetailsState.initial());
+    GetIt.I.registerSingleton<CrowdActionDetailsBloc>(crowdActionDetailsBloc);
+  });
+
+  tearDownAll(() {
+    GetIt.instance.unregister<TopParticipantsBloc>();
+    GetIt.instance.unregister<CrowdActionDetailsBloc>();
+  });
+
+  testWidgets(
+      "should display loading shimmer "
+      "when crowdaction list is empty", (WidgetTester tester) async {
+    // arrange
+    await tester.pumpSpotlightCrowdActions();
+    // act
+
+    // assert
+    expect(find.byType(SpotlightEmptyHeader), findsOneWidget);
+    expect(find.byType(ExpandablePageView), findsNothing);
+    expect(find.byType(DotsIndicator), findsNothing);
+  });
+
+  testWidgets(
+      "should display crowdactions page view "
+      "when crowdaction list is not empty", (WidgetTester tester) async {
+    // arrange
+    await tester.pumpSpotlightCrowdActions(
+      crowdActions: crowdActions.map((e) => e.toDomain()).toList(),
+    );
+    // act
+
+    // assert
+    expect(find.byType(SpotlightEmptyHeader), findsNothing);
+    expect(find.byType(ExpandablePageView), findsOneWidget);
+    expect(find.byType(DotsIndicator), findsOneWidget);
+  });
+}
+
+extension WidgetTesterX on WidgetTester {
+  Future<void> pumpSpotlightCrowdActions(
+      {List<CrowdAction>? crowdActions}) async {
+    await pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: SpotlightCrowdActions(
+            pages: crowdActions ?? [],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/test/presentation/home/widgets/current_upcoming_layout_test.dart
+++ b/test/presentation/home/widgets/current_upcoming_layout_test.dart
@@ -1,0 +1,88 @@
+import 'package:collaction_app/application/crowdaction/spotlight/spotlight_bloc.dart';
+import 'package:collaction_app/presentation/home/widgets/current_upcoming_layout.dart';
+import 'package:collaction_app/presentation/shared_widgets/micro_crowdaction_card.dart';
+import 'package:collaction_app/presentation/shared_widgets/micro_crowdaction_card_loading.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../application/crowdaction/spotlight/spotlight_bloc.mocks.dart';
+import '../../../test_utilities.dart';
+import '../../../utils/crowdactions.dart';
+
+void main() {
+  final crowdActionsList = crowdActions;
+  late SpotlightBloc spotlightBloc;
+
+  setUpAll(() {
+    dotenv.testLoad(fileInput: tDotEnv);
+  });
+
+  setUp(() {
+    spotlightBloc = MockSpotlightBloc();
+  });
+
+  testWidgets(
+      "should show loading state "
+      "when loading spotlight crowdactions", (WidgetTester tester) async {
+    // arrange
+    when(() => spotlightBloc.state)
+        .thenAnswer((_) => SpotlightState.fetchingCrowdSpotLightActions());
+    await tester.pumpCurrentAndUpcomingLayout(spotlightBloc);
+
+    // assert
+    expect(find.byType(MicroCrowdActionCardLoading), findsWidgets);
+    expect(find.byType(MicroCrowdActionCard), findsNothing);
+  });
+
+  testWidgets(
+      "should show loading state "
+      "when spotlight crowdactions list is empty", (WidgetTester tester) async {
+    // arrange
+    when(() => spotlightBloc.state).thenAnswer(
+      (_) => SpotlightState.spotLightCrowdActions([]),
+    );
+    await tester.pumpCurrentAndUpcomingLayout(spotlightBloc);
+
+    // assert
+    expect(find.byType(MicroCrowdActionCardLoading), findsWidgets);
+    expect(find.byType(MicroCrowdActionCard), findsNothing);
+  });
+
+  testWidgets(
+      "should show [MicroCrowdActionCard] list "
+      "when spotlight crowdactions are loaded", (WidgetTester tester) async {
+    // arrange
+    when(() => spotlightBloc.state).thenAnswer(
+      (_) => SpotlightState.spotLightCrowdActions(
+        crowdActionsList.map((e) => e.toDomain()).toList(),
+      ),
+    );
+    await tester.pumpCurrentAndUpcomingLayout(spotlightBloc);
+
+    // assert
+    expect(find.byType(MicroCrowdActionCardLoading), findsNothing);
+    expect(find.byType(MicroCrowdActionCard),
+        findsNWidgets(crowdActionsList.length));
+  });
+}
+
+extension WidgetTesterX on WidgetTester {
+  Future<void> pumpCurrentAndUpcomingLayout(
+    SpotlightBloc bloc, {
+    bool isCurrent = true,
+  }) async {
+    await pumpWidget(
+      MaterialApp(
+        home: BlocProvider.value(
+          value: bloc,
+          child: Scaffold(
+            body: CurrentAndUpcomingLayout(isCurrent: isCurrent),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/test/utils/crowdactions.dart
+++ b/test/utils/crowdactions.dart
@@ -2,76 +2,214 @@ import 'package:collaction_app/infrastructure/crowdaction/crowdaction_dto.dart';
 
 final _crowdActionsRawData = [
   {
-    "crowdactionID": "sustainability#food#veganMonth21-12",
-    "title": "Vegan month 2021",
-    "description": "Let's be vegan for a month",
-    "category": "sustainability",
-    "location": "NL#Amsterdam",
-    "date_start": "2021-12-01",
-    "date_end": "2021-12-31",
-    "date_limit_join": "2021-12-20",
-    "password_join": "myEvent-myCompany2021",
-    "commitment_options": [
+    "id": "62ceb7110b5e88ce294628a1",
+    "type": "FOOD",
+    "title": "Veganuary",
+    "description":
+        "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam varius ac ligula quis aliquet. Donec nisi leo, rhoncus ac nulla quis, egestas ornare quam. Nunc nibh ex, venenatis quis maximus vitae, elementum sed urna. Morbi sagittis metus nibh, non lacinia ipsum faucibus eu. Nulla vehicula purus eget congue auctor.",
+    "category": "SUSTAINABILITY",
+    "subcategory": "FOOD",
+    "location": {"code": "NL", "name": "Netherlands"},
+    "slug": "veganuary",
+    "password": "veganuary-2022",
+    "participantCount": 9,
+    "images": {
+      "card": "crowdaction-cards/628a7fa741b5aa3af6582a07.png",
+      "banner": "crowdaction-banners/628a7fa741b5aa3af6582a07.png"
+    },
+    "commitmentOptions": [
       {
-        "id": "vegetarian",
-        "label": "Becoming vegetarian",
+        "type": "FOOD",
+        "label": "5/7 Days a week",
+        "description": "In case you prefer to exclude weekends",
+        "points": -10,
+        "blocks": [],
+        "id": "62b637e0c5d78b613a3cc6d2"
+      },
+      {
+        "type": "FOOD",
+        "label": "Vegan",
         "description":
-            "I will not eat any meat from any animal (including fish).",
-        "requires": [
-          {
-            "id": "no-beef",
-            "label": "Not eating beef",
-            "description": "I will avoid eating beef (Goodbye stake)."
-          }
-        ]
+            "Commit to eating no product or by-product from any and all animals",
+        "points": 50,
+        "blocks": [
+          "62b63863c5d78b613a3cc6d6",
+          "62b638a6c5d78b613a3cc6d8",
+          "62b638c8c5d78b613a3cc6da",
+          "62b638d9c5d78b613a3cc6dc"
+        ],
+        "id": "62b6381fc5d78b613a3cc6d4"
+      },
+      {
+        "type": "FOOD",
+        "label": "Vegetarian",
+        "description":
+            "Commit to eating no meat product or by-product of any and all animals",
+        "points": 40,
+        "blocks": ["62b638a6c5d78b613a3cc6d8", "62b638c8c5d78b613a3cc6da"],
+        "id": "62b63863c5d78b613a3cc6d6"
+      },
+      {
+        "type": "FOOD",
+        "label": "Pescatarian",
+        "description":
+            "Commit to eating no meat or poultry from animals, except fish and other seafood",
+        "points": 30,
+        "blocks": ["62b638c8c5d78b613a3cc6da"],
+        "id": "62b638a6c5d78b613a3cc6d8"
+      },
+      {
+        "type": "FOOD",
+        "label": "No Beef",
+        "description": "Commit to eating no beef",
+        "points": 20,
+        "blocks": [],
+        "id": "62b638c8c5d78b613a3cc6da"
+      },
+      {
+        "type": "FOOD",
+        "label": "No Dairy",
+        "description":
+            "Commit to eating no dairy products such as cheese and milk",
+        "points": 10,
+        "blocks": [],
+        "id": "62b638d9c5d78b613a3cc6dc"
       }
     ],
-    "participant_count": 1,
-    "top_participants": [
-      {"name": "Peter Parker", "userID": "6620cf87-44ed-456e-9798-d5cbeb7fa10a"}
-    ],
-    "images": {
-      "card":
-          "https://images.unsplash.com/photo-1512621776951-a57141f2eefd?ixlib=rb-1.2.1\u0026ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8\u0026auto=format\u0026fit=crop\u0026w=640",
-      "banner":
-          "https://images.unsplash.com/photo-1512621776951-a57141f2eefd?ixlib=rb-1.2.1\u0026ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8\u0026auto=format\u0026fit=crop\u0026w=640"
-    }
+    "status": "STARTED",
+    "joinStatus": "OPEN",
+    "startAt": "2022-07-22T15:00:00.000Z",
+    "endAt": "2024-12-22T15:00:00.000Z",
+    "joinEndAt": "2023-12-22T15:00:00.000Z",
+    "createdAt": "2022-07-13T12:14:09.104Z",
+    "updatedAt": "2022-11-19T23:06:11.947Z",
+    "badges": []
   },
   {
-    "crowdactionID": "sustainability#food#veganMonth22-12",
-    "title": "Vegan month 2022",
-    "description": "Let's be vegan for a month",
-    "category": "sustainability",
-    "location": "NL#Amsterdam",
-    "date_start": "2022-12-01",
-    "date_end": "2022-12-31",
-    "date_limit_join": "2022-12-20",
-    "password_join": "myEvent-myCompany2022",
-    "commitment_options": [
+    "id": "6364ca939d4f5dffc3fe8e25",
+    "type": "ENERGY",
+    "title": "Steun je School",
+    "description":
+        "Tijdens deze campagne staat het thema energiebesparing centraal, in het bijzonder op scholen. We bevinden ons in een energiecrisis en alleen samen komen we eruit! Voor meer informatie, neem een kijkje op collaction.org/steunschool.",
+    "category": "Duurzaamheid",
+    "subcategory": "Energie",
+    "location": {"code": "NL", "name": "Netherlands"},
+    "slug": "steun-je-school",
+    "password": "",
+    "participantCount": 3,
+    "images": {
+      "card": "crowdaction-cards/education_january.jpg",
+      "banner": "crowdaction-banners/education_january.jpg"
+    },
+    "commitmentOptions": [
       {
-        "id": "vegetarian",
-        "label": "Becoming vegetarian",
-        "description":
-            "I will not eat any meat from any animal (including fish).",
-        "requires": [
-          {
-            "id": "no-beef",
-            "label": "Not eating beef",
-            "description": "I will avoid eating beef (Goodbye stake)."
-          }
-        ]
+        "type": "ENERGY",
+        "label": "SUSTAINABILITY",
+        "description": "",
+        "points": 10,
+        "blocks": [],
+        "id": "6364bcbf9d4f5dffc3fe8e19"
       }
     ],
-    "participant_count": 1,
-    "top_participants": [
-      {"name": "Peter Parker", "userID": "6620cf87-44ed-456e-9798-d5cbeb7fa10a"}
-    ],
+    "status": "STARTED",
+    "joinStatus": "OPEN",
+    "startAt": "2022-12-31T23:00:00.000Z",
+    "endAt": "2023-01-31T23:00:00.000Z",
+    "joinEndAt": "2023-01-31T23:00:00.000Z",
+    "createdAt": "2022-07-13T12:14:09.104Z",
+    "updatedAt": "2022-12-31T23:00:00.431Z",
+    "badges": []
+  },
+  {
+    "id": "6364d440187f67b3798ca86e",
+    "type": "FOOD",
+    "title": "The Food Initiative",
+    "description":
+        "Improve your eating habits, and downscale your CO2 footprint!",
+    "category": "SUSTAINABILITY",
+    "subcategory": "FOOD",
+    "location": {"code": "NL", "name": "Netherlands"},
+    "slug": "the-food-initiative",
+    "participantCount": 0,
     "images": {
-      "card":
-          "https://images.unsplash.com/photo-1498837167922-ddd27525d352?ixlib=rb-1.2.1\u0026ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8\u0026auto=format\u0026fit=crop\u0026w=640",
-      "banner":
-          "https://images.unsplash.com/photo-1498837167922-ddd27525d352?ixlib=rb-1.2.1\u0026ixid=MnwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8\u0026auto=format\u0026fit=crop\u0026w=640"
-    }
+      "card": "crowdaction-cards/placeholder.png",
+      "banner": "crowdaction-banners/placeholder.png"
+    },
+    "commitmentOptions": [
+      {
+        "type": "FOOD",
+        "label": "5/7 Days a week",
+        "description": "In case you prefer to exclude weekends",
+        "points": -10,
+        "blocks": [],
+        "icon": "working-days-only",
+        "id": "62b637e0c5d78b613a3cc6d2"
+      },
+      {
+        "type": "FOOD",
+        "label": "Vegan",
+        "description": "Commit to eating no product or by-product from animals",
+        "points": 50,
+        "blocks": [
+          "62b63863c5d78b613a3cc6d6",
+          "62b638a6c5d78b613a3cc6d8",
+          "62b638c8c5d78b613a3cc6da",
+          "62b638d9c5d78b613a3cc6dc"
+        ],
+        "icon": "vegan",
+        "id": "62b6381fc5d78b613a3cc6d4"
+      },
+      {
+        "type": "FOOD",
+        "label": "Vegetarian",
+        "description":
+            "Commit to eating no meat product or by-product from animals",
+        "points": 40,
+        "blocks": ["62b638a6c5d78b613a3cc6d8", "62b638c8c5d78b613a3cc6da"],
+        "icon": "vegetarian",
+        "id": "62b63863c5d78b613a3cc6d6"
+      },
+      {
+        "type": "FOOD",
+        "label": "Pescatarian",
+        "description":
+            "Commit to eating no meat or poultry from animals, except fish and other seafood",
+        "points": 30,
+        "blocks": ["62b638c8c5d78b613a3cc6da"],
+        "icon": "pescatarian",
+        "id": "62b638a6c5d78b613a3cc6d8"
+      },
+      {
+        "type": "FOOD",
+        "label": "No Beef",
+        "description": "Commit to eating no beef",
+        "points": 20,
+        "blocks": [],
+        "icon": "no-beef",
+        "id": "62b638c8c5d78b613a3cc6da"
+      },
+      {
+        "type": "FOOD",
+        "label": "No Dairy",
+        "description":
+            "Commit to eating no dairy products such as cheese and milk",
+        "points": 10,
+        "blocks": [],
+        "icon": "no-dairy",
+        "id": "62b638d9c5d78b613a3cc6dc"
+      }
+    ],
+    "status": "WAITING",
+    "joinStatus": "OPEN",
+    "startAt": "2022-11-04T15:00:00.000Z",
+    "endAt": "2024-12-22T15:00:00.000Z",
+    "joinEndAt": "2023-12-22T15:00:00.000Z",
+    "createdAt": "2022-11-04T08:58:40.237Z",
+    "updatedAt": "2022-11-04T08:58:40.237Z",
+    "badges": [
+      {"tier": "DIAMOND", "awardType": "TIER", "minimumCheckIns": 0},
+      {"tier": "GOLD", "awardType": "ALL", "minimumCheckIns": 0}
+    ]
   }
 ];
 


### PR DESCRIPTION
@Edamijueda and I decided to fix Issue #335 . 
Turns out the spotlight header doesn't act well without data. This was due to the `ExpandablePageView` and `DotsIndicator` throwing exceptions when offered an empty list. For now we've created skeleton loaders but will still need the empty designs as we go forward.

| | | |
| -- | -- | -- |
| ![Simulator Screen Shot - iPhone 13 - 2023-01-06 at 01 22 20](https://user-images.githubusercontent.com/15793624/210909482-dd9d022d-4139-4892-984b-7294005fe36d.png) | ![Simulator Screen Shot - iPhone 13 - 2023-01-06 at 01 22 27](https://user-images.githubusercontent.com/15793624/210909478-3b5b8b2c-bf0b-4fce-ad51-5067581a89bb.png) |  ![Simulator Screen Shot - iPhone 13 - 2023-01-06 at 01 22 31](https://user-images.githubusercontent.com/15793624/210909468-e9bd04f9-5ef0-4807-8de8-d5502bbe02db.png) 

Closes #335 